### PR TITLE
feat: add NERIS API integration for incident statistics

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -1,0 +1,52 @@
+name: Update Incident Stats
+
+on:
+  schedule:
+    # Run daily at 6 AM UTC (10 PM PST / 11 PM PDT)
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    # Allow manual trigger from GitHub Actions UI
+
+jobs:
+  update-stats:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Generate incident statistics
+        env:
+          NERIS_CLIENT_ID: ${{ secrets.NERIS_CLIENT_ID }}
+          NERIS_CLIENT_SECRET: ${{ secrets.NERIS_CLIENT_SECRET }}
+          NERIS_ENTITY_ID: ${{ secrets.NERIS_ENTITY_ID }}
+          NERIS_USE_TEST_API: ${{ vars.NERIS_USE_TEST_API || 'false' }}
+          STATS_DAYS: '30'
+        run: node src/scripts/generate-stats.mjs
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet src/_data/stats.json; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/_data/stats.json
+          git commit -m "chore: update incident statistics from NERIS
+
+          Auto-generated daily update of incident statistics."
+          git push

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "SJIFIRE",
   "version": "2.0.0",
   "scripts": {
-    "stats": "node src/scripts/generate-stats.mjs",
+    "stats": "node scripts/generate-stats.mjs",
     "sync-personnel": "node scripts/sync-personnel.mjs",
     "dev": "eleventy --serve --port=8080",
     "build": "eleventy",


### PR DESCRIPTION
## Summary
- Replace ESO with NERIS for pulling incident data
- Add ESM API client for NERIS REST API with OAuth2 authentication
- Add daily scheduled GitHub Action (6 AM UTC) to update `stats.json`
- Add `npm run stats` script for local testing

## Required GitHub Secrets
Before this workflow will run successfully, add these secrets:
- `NERIS_CLIENT_ID` - OAuth2 client ID from NERIS
- `NERIS_CLIENT_SECRET` - OAuth2 client secret
- `NERIS_ENTITY_ID` - Fire department NERIS ID

## Test plan
- [ ] Add NERIS secrets to GitHub repository
- [ ] Manually trigger workflow via Actions UI to verify it runs
- [ ] Verify `stats.json` is updated with NERIS data
- [ ] Adjust incident type mappings and region boundaries as needed