### PR TITLE
Fix Join Us page and navigation link

### DIFF
--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -1,5 +1,5 @@
 {
-  "header_highlight_url": "about/join/",
+  "header_highlight_url": "/about/join/",
   "items": [
     {
       "label": "About",

--- a/src/pages/about/join.mdx
+++ b/src/pages/about/join.mdx
@@ -7,7 +7,9 @@ nav_order: 2
 
 SJIFR is accepting applications for the upcoming training class.  Accepted applicants will be trained as structural and wildland firefighters.
 
-Applicants are required to fill out an [online application](https://forms.office.com/pages/responsepage.aspx?id=j4QiQRfDZ0KcB3xQQVDRva2d14yWAXNFl-Q6Prz2fIRUOFNSWEYyUEsxS0dFNVpITkdEWFg3RklHWCQlQCN0PWcu&route=shorturl) with District 3. Fill one out any time, and the District will contact you when a training is next available.
+Applicants are required to fill out an online application with District 3. Fill one out any time, and the District will contact you when a training is next available.
+
+<a class="btn btn-secondary" href="https://forms.office.com/pages/responsepage.aspx?id=j4QiQRfDZ0KcB3xQQVDRva2d14yWAXNFl-Q6Prz2fIRUOFNSWEYyUEsxS0dFNVpITkdEWFg3RklHWCQlQCN0PWcu&route=shorturl">Volunteer Application</a>
 
 ### Training class information
 

--- a/src/pages/about/join.mdx
+++ b/src/pages/about/join.mdx
@@ -5,9 +5,7 @@ nav_order: 2
 
 ## Volunteer Opportunities
 
-SJIFR is accepting applications for the upcoming training class.  Accepted applicants will be trained as structural and wildland firefighters.
-
-Applicants are required to fill out an online application with District 3. Fill one out any time, and the District will contact you when a training is next available.
+SJIFR accepts applications for upcoming training throughout the year. Applicants are required to fill out an online application with District 3. Fill one out any time, and the District will contact you when a training is next available.
 
 <a class="btn btn-secondary" href="https://forms.office.com/pages/responsepage.aspx?id=j4QiQRfDZ0KcB3xQQVDRva2d14yWAXNFl-Q6Prz2fIRUOFNSWEYyUEsxS0dFNVpITkdEWFg3RklHWCQlQCN0PWcu&route=shorturl">Volunteer Application</a>
 


### PR DESCRIPTION
## Summary
- Fix invalid navigation highlight link (missing leading slash)
- Convert volunteer application inline link to styled button

## Test plan
- [ ] Verify "Join Us" highlight link in header navigation works
- [ ] Verify "Volunteer Application" button displays correctly on Join Us page