### PR TITLE
fix: add permissions to close PR job for Azure Static Web Apps

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -88,6 +88,10 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     steps:
       - name: Close Pull Request
         id: closepullrequest


### PR DESCRIPTION
## Summary
- Added missing `permissions` block to the close_pull_request_job
- Matches the permissions from the build_and_deploy_job

The close job was failing with "No matching static site found" even though the preview environment exists. This may be due to missing permissions needed to identify the preview.

## Test plan
- [ ] Merge this PR and close the tinacms-azure PR to test if the close job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)