### PR TITLE
fix: add OIDC authentication to close PR job for Azure SWA

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -93,6 +93,18 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Install OIDC Client from Core Package
+        run: npm install @actions/core@1.6.0 @actions/http-client
+
+      - name: Get Id Token
+        uses: actions/github-script@v6
+        id: idtoken
+        with:
+          script: |
+            const coredemo = require('@actions/core')
+            return await coredemo.getIDToken()
+          result-encoding: string
+
       - name: Close Pull Request
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
@@ -100,3 +112,4 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_JOLLY_MOSS_0DB15021E }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "close"
+          github_id_token: ${{ steps.idtoken.outputs.result }}

--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -88,6 +88,10 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     steps:
       - name: Close Pull Request
         id: closepullrequest


### PR DESCRIPTION
## Summary
The close job needs the same OIDC token authentication as the deploy job to properly authenticate with Azure when using GitHub authorization policy.

Added:
- Install OIDC Client step
- Get Id Token step  
- Pass `github_id_token` to the close action

Based on: https://github.com/quaz579/against-the-spread/pull/22
Related issue: https://github.com/Azure/static-web-apps/issues/1638

## Test plan
- [ ] Merge this PR
- [ ] Close a PR that has a preview environment (e.g., tinacms-azure #21)
- [ ] Verify the close job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)