### PR TITLE
feat: integrate Facebook posts into homepage feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,3 +119,30 @@ export MS_GRAPH_CLIENT_ID="your-client-id"
 export MS_GRAPH_CLIENT_SECRET="your-client-secret"
 npm run sync-personnel
 ```
+
+### Facebook Posts Integration
+
+Facebook posts are fetched from the Graph API during build and intermingled with regular posts on the homepage.
+
+**Files:**
+- `src/_data/facebook_posts.js` - Fetches posts from Facebook Graph API
+- `src/_data/combined_feed.js` - Merges posts and Facebook posts chronologically
+
+**Required Environment Variables:**
+- `FACEBOOK_PAGE_ID` - The Facebook Page ID (numeric ID, not username)
+- `FACEBOOK_ACCESS_TOKEN` - Long-lived Page Access Token
+
+**Setup:**
+1. Create a Meta App at developers.facebook.com
+2. Add the Facebook Login product
+3. Generate a Page Access Token for the SJIFire page
+4. Convert to long-lived token (60+ days) or set up token refresh
+
+**Local Testing:**
+```bash
+export FACEBOOK_PAGE_ID="your-page-id"
+export FACEBOOK_ACCESS_TOKEN="your-access-token"
+npm run build
+```
+
+Without credentials, Facebook posts are skipped and only regular posts display.

--- a/src/_data/combined_feed.js
+++ b/src/_data/combined_feed.js
@@ -1,0 +1,17 @@
+const posts = require("./posts.js");
+const facebookPosts = require("./facebook_posts.js");
+
+/**
+ * Combined feed of posts and Facebook posts, sorted by date (newest first when reversed).
+ * This allows the homepage to show an intermingled chronological feed.
+ */
+module.exports = async function () {
+  // facebook_posts.js exports an async function
+  const fbPosts = await facebookPosts();
+
+  // Merge both arrays
+  const allPosts = [...posts, ...fbPosts];
+
+  // Sort by date ascending (will be reversed in template for newest first)
+  return allPosts.sort((a, b) => new Date(a.date) - new Date(b.date));
+};

--- a/src/_data/facebook_posts.js
+++ b/src/_data/facebook_posts.js
@@ -1,3 +1,4 @@
+/* global fetch */
 const { DateTime } = require("luxon");
 
 const FACEBOOK_PAGE_ID = process.env.FACEBOOK_PAGE_ID;
@@ -76,7 +77,7 @@ function transformPost(fbPost) {
 
   return {
     post_type: "Facebook",
-    date: fbPost.created_time,
+    date: date.toISO(),
     title: extractTitle(fbPost.message),
     lede: extractLede(fbPost.message),
     url: fbPost.permalink_url,

--- a/src/_data/facebook_posts.js
+++ b/src/_data/facebook_posts.js
@@ -1,0 +1,101 @@
+const { DateTime } = require("luxon");
+
+const FACEBOOK_PAGE_ID = process.env.FACEBOOK_PAGE_ID;
+const FACEBOOK_ACCESS_TOKEN = process.env.FACEBOOK_ACCESS_TOKEN;
+const FACEBOOK_API_VERSION = "v18.0";
+const MAX_POSTS = 10;
+
+/**
+ * Fetches posts from the Facebook Graph API.
+ * Returns empty array if credentials are missing or on error.
+ */
+async function fetchFacebookPosts() {
+  if (!FACEBOOK_PAGE_ID || !FACEBOOK_ACCESS_TOKEN) {
+    console.log("Facebook credentials not configured, skipping Facebook posts");
+    return [];
+  }
+
+  const fields = "id,message,created_time,permalink_url,full_picture";
+  const url = `https://graph.facebook.com/${FACEBOOK_API_VERSION}/${FACEBOOK_PAGE_ID}/posts?fields=${fields}&limit=${MAX_POSTS}&access_token=${FACEBOOK_ACCESS_TOKEN}`;
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.warn("Facebook API error:", response.status, error);
+      return [];
+    }
+
+    const data = await response.json();
+    return data.data || [];
+  } catch (error) {
+    console.warn("Facebook fetch error:", error.message);
+    return [];
+  }
+}
+
+/**
+ * Extracts a title from a Facebook post message.
+ * Uses first line if it's short enough, otherwise truncates.
+ */
+function extractTitle(message) {
+  if (!message) return "Facebook Post";
+
+  const firstLine = message.split("\n")[0].trim();
+  if (firstLine.length <= 80) {
+    return firstLine;
+  }
+
+  // Truncate at word boundary
+  const truncated = firstLine.substring(0, 77).replace(/\s+\S*$/, "");
+  return truncated + "...";
+}
+
+/**
+ * Extracts a lede/summary from a Facebook post message.
+ * Returns the full message truncated if needed.
+ */
+function extractLede(message) {
+  if (!message) return "";
+
+  if (message.length <= 200) {
+    return message;
+  }
+
+  // Truncate at word boundary
+  const truncated = message.substring(0, 197).replace(/\s+\S*$/, "");
+  return truncated + "...";
+}
+
+/**
+ * Transforms Facebook API post data into our standard post format.
+ */
+function transformPost(fbPost) {
+  const date = DateTime.fromISO(fbPost.created_time, { zone: "utc" });
+
+  return {
+    post_type: "Facebook",
+    date: fbPost.created_time,
+    title: extractTitle(fbPost.message),
+    lede: extractLede(fbPost.message),
+    url: fbPost.permalink_url,
+    external: true, // Flag to indicate this links externally
+    featured_image: fbPost.full_picture
+      ? {
+          source: fbPost.full_picture,
+          external: true,
+        }
+      : null,
+    facebook_id: fbPost.id,
+  };
+}
+
+module.exports = async function () {
+  const fbPosts = await fetchFacebookPosts();
+
+  return fbPosts
+    .filter((post) => post.message) // Only posts with text content
+    .map(transformPost)
+    .sort((a, b) => new Date(a.date) - new Date(b.date));
+};

--- a/src/_includes/post_type_icons.liquid
+++ b/src/_includes/post_type_icons.liquid
@@ -13,4 +13,6 @@
     <svg><use xlink:href='#fact-check' /></svg>
   {%- when 'Department Highlight' -%}
     <svg><use xlink:href='#highlight' /></svg>
+  {%- when 'Facebook' -%}
+    <svg><use xlink:href='#facebook' /></svg>
 {%- endcase -%}

--- a/src/pages/homepage.liquid
+++ b/src/pages/homepage.liquid
@@ -27,7 +27,7 @@ scripts: '<script src="/js/carousel.js" defer></script>'
   </section>
   <div class="l-grid__main block-content">
     <ul class="l-grid l-grid--auto">
-      {% assign limitedPosts = posts | reverse | limit: homepage.number_news_stories %}
+      {% assign limitedPosts = combined_feed | reverse | limit: homepage.number_news_stories %}
       {% for post in limitedPosts %}
         <li class="card">
           <div class="card__body">
@@ -37,7 +37,7 @@ scripts: '<script src="/js/carousel.js" defer></script>'
               {{ post.post_type }}
             </div>
             <h3 class="news__headline">
-              <a href="{{ post.url }}/">
+              <a href="{{ post.url }}{% unless post.external %}/{% endunless %}"{% if post.external %} target="_blank" rel="noopener"{% endif %}>
                 {{ post.title }}
               </a>
             </h3>
@@ -49,7 +49,7 @@ scripts: '<script src="/js/carousel.js" defer></script>'
             </div>
           </div>
           <div class="card__footer">
-            <a href="{{ post.url }}/" class="news__readmore" aria-label="Read more about {{ post.title }}">Read more <svg aria-hidden="true"><use xlink:href="#right-arrow"></svg></a>
+            <a href="{{ post.url }}{% unless post.external %}/{% endunless %}" class="news__readmore" aria-label="Read more about {{ post.title }}"{% if post.external %} target="_blank" rel="noopener"{% endif %}>Read more <svg aria-hidden="true"><use xlink:href="#right-arrow"></svg></a>
           </div>
         </li>
       {% endfor %}


### PR DESCRIPTION
## Summary
Integrates Facebook posts into the homepage feed, intermingled chronologically with regular posts.

**Changes:**
- `src/_data/facebook_posts.js` - Fetches posts from Facebook Graph API at build time
- `src/_data/combined_feed.js` - Merges posts + Facebook posts, sorted by date
- Homepage uses combined feed with external link support (opens Facebook in new tab)
- Facebook posts show with Facebook icon and "Facebook" type label
- Removed Facebook iframe widget from sidebar (replaced by integrated feed)

**Required env vars:**
- `FACEBOOK_PAGE_ID` - Numeric Facebook Page ID
- `FACEBOOK_ACCESS_TOKEN` - Long-lived Page Access Token

Without credentials, gracefully falls back to showing regular posts only.

## Test plan
- [x] Build passes without Facebook credentials (empty array returned)
- [ ] Test with valid Facebook credentials (pending page access)
- [ ] Verify Facebook posts display correctly with icon, title, lede, date
- [ ] Verify "Read more" links to actual Facebook post

## Notes
Waiting for Editor role on SJIFire Facebook page to generate access token for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)