### PR TITLE
fix: remove invalid inputs from SWA deploy action

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -66,8 +66,6 @@ jobs:
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
-          node-version: '20'
-          cache: 'npm'
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_JOLLY_MOSS_0DB15021E }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"


### PR DESCRIPTION
## Summary
- Removes `node-version` and `cache` inputs from the Azure/static-web-apps-deploy action
- These inputs are not valid for this action and cause warning messages in workflow runs

The warning was:
> Unexpected input(s) 'node-version', 'cache', valid inputs are ['action', 'azure_static_web_apps_api_token', ...]

## Test plan
- [x] Verify workflow runs without the warning about unexpected inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)