### PR TITLE
fix: index TinaCMS GraphQL schema to Cosmos DB during build

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -47,7 +47,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
-          GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
           COSMOS_DB_CONNECTION_STRING: ${{ secrets.COSMOS_DB_CONNECTION_STRING }}
           COSMOS_DB_NAME: ${{ secrets.COSMOS_DB_NAME }}
 
@@ -84,7 +83,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
-          GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
           AAD_CLIENT_ID: ${{ secrets.AAD_CLIENT_ID }}
           AAD_CLIENT_SECRET: ${{ secrets.AAD_CLIENT_SECRET }}
           ALLOWED_EDITOR_GROUPS: ${{ secrets.ALLOWED_EDITOR_GROUPS }}

--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           COSMOS_DB_CONNECTION_STRING: ${{ secrets.COSMOS_DB_CONNECTION_STRING }}
           COSMOS_DB_NAME: ${{ secrets.COSMOS_DB_NAME }}
+          GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
 
       - name: Build 11ty site
         run: npm run build
@@ -80,6 +81,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
+          GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
           AAD_CLIENT_ID: ${{ secrets.AAD_CLIENT_ID }}
           AAD_CLIENT_SECRET: ${{ secrets.AAD_CLIENT_SECRET }}
           ALLOWED_EDITOR_GROUPS: ${{ secrets.ALLOWED_EDITOR_GROUPS }}

--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -41,12 +41,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build TinaCMS
+      - name: Build TinaCMS and index schema
         run: npx tinacms build --skip-cloud-checks
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPO: ${{ github.event.repository.name }}
+          GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
           COSMOS_DB_CONNECTION_STRING: ${{ secrets.COSMOS_DB_CONNECTION_STRING }}
           COSMOS_DB_NAME: ${{ secrets.COSMOS_DB_NAME }}
-          GITHUB_BRANCH: ${{ github.head_ref || github.ref_name }}
 
       - name: Build 11ty site
         run: npm run build

--- a/api/tina/database.js
+++ b/api/tina/database.js
@@ -21,6 +21,10 @@ async function createProdDatabase() {
   const githubToken = await getGitHubToken();
   console.log("  GitHub token generated successfully");
 
+  // Sanitize branch name for MongoDB collection (replace / with -)
+  const collectionName = branch.replace(/\//g, "-");
+  console.log(`  Collection: ${collectionName}`);
+
   return createDatabase({
     gitProvider: new GitHubProvider({
       branch,
@@ -29,7 +33,7 @@ async function createProdDatabase() {
       token: githubToken,
     }),
     databaseAdapter: new MongodbLevel({
-      collectionName: branch,
+      collectionName,
       dbName: process.env.COSMOS_DB_NAME || "tinacms",
       mongoUri: process.env.COSMOS_DB_CONNECTION_STRING,
     }),

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -22,7 +22,7 @@ const getApiUrl = () => {
 };
 
 export default defineConfig({
-  branch: process.env.GITHUB_BRANCH || process.env.TINA_BRANCH || "main",
+  branch: process.env.TINA_BRANCH || "main",
 
   // Self-hosted: use custom backend in production, local mode for development
   contentApiUrlOverride: getApiUrl(),

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -22,7 +22,7 @@ const getApiUrl = () => {
 };
 
 export default defineConfig({
-  branch: process.env.TINA_BRANCH || "main",
+  branch: process.env.GITHUB_BRANCH || process.env.TINA_BRANCH || "main",
 
   // Self-hosted: use custom backend in production, local mode for development
   contentApiUrlOverride: getApiUrl(),

--- a/tina/database.ts
+++ b/tina/database.ts
@@ -1,5 +1,27 @@
-import { createLocalDatabase } from "@tinacms/datalayer";
+import { createDatabase, createLocalDatabase } from "@tinacms/datalayer";
+// @ts-ignore - no types for mongodb-level
+import { MongodbLevel } from "mongodb-level";
 
-// For build/dev, use local database
-// Production database (Cosmos DB) is handled by api/tina/database.mjs at runtime
-export default createLocalDatabase();
+const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === "true";
+const cosmosConnectionString = process.env.COSMOS_DB_CONNECTION_STRING;
+
+// Use Cosmos DB during build (for schema indexing) when connection string is available
+// Use local database for local development
+let database;
+
+if (isLocal || !cosmosConnectionString) {
+  // Local development: use local filesystem database
+  database = createLocalDatabase();
+} else {
+  // Build/production: use Cosmos DB to index schema
+  const branch = process.env.GITHUB_BRANCH || process.env.HEAD || "main";
+  database = createDatabase({
+    databaseAdapter: new MongodbLevel({
+      collectionName: branch,
+      dbName: process.env.COSMOS_DB_NAME || "tinacms",
+      mongoUri: cosmosConnectionString,
+    }),
+  });
+}
+
+export default database;

--- a/tina/database.ts
+++ b/tina/database.ts
@@ -14,24 +14,18 @@ let database;
 
 if (isLocal || !cosmosConnectionString || !githubToken) {
   // Local development: use local filesystem database
-  console.log("[TinaCMS Build] Using local database");
-  console.log(`  isLocal: ${isLocal}`);
-  console.log(`  hasCosmosConnection: ${!!cosmosConnectionString}`);
-  console.log(`  hasGithubToken: ${!!githubToken}`);
   database = createLocalDatabase();
 } else {
   // CI build: use Cosmos DB to index schema with GitHub provider
+  // Always use 'main' collection for schema (shared across all environments)
+  // GitHubProvider branch determines which content is read from Git
   const branch = process.env.GITHUB_BRANCH || "main";
-  // Sanitize branch name for MongoDB collection (replace / with -)
-  const collectionName = branch.replace(/\//g, "-");
   const owner = process.env.GITHUB_OWNER || process.env.GITHUB_REPOSITORY?.split("/")[0];
   const repo = process.env.GITHUB_REPO || process.env.GITHUB_REPOSITORY?.split("/")[1];
 
-  console.log("[TinaCMS Build] Using Cosmos DB database adapter");
-  console.log(`  Branch: ${branch}`);
-  console.log(`  Collection: ${collectionName}`);
-  console.log(`  Owner: ${owner}`);
-  console.log(`  Repo: ${repo}`);
+  console.log("[TinaCMS Build] Indexing schema to Cosmos DB");
+  console.log(`  Git Branch: ${branch}`);
+  console.log(`  Collection: main`);
 
   database = createDatabase({
     gitProvider: new GitHubProvider({
@@ -41,7 +35,7 @@ if (isLocal || !cosmosConnectionString || !githubToken) {
       token: githubToken,
     }),
     databaseAdapter: new MongodbLevel({
-      collectionName,
+      collectionName: "main",
       dbName: process.env.COSMOS_DB_NAME || "tinacms",
       mongoUri: cosmosConnectionString,
     }),

--- a/tina/database.ts
+++ b/tina/database.ts
@@ -1,21 +1,33 @@
 import { createDatabase, createLocalDatabase } from "@tinacms/datalayer";
 // @ts-ignore - no types for mongodb-level
 import { MongodbLevel } from "mongodb-level";
+// @ts-ignore - no types for tinacms-gitprovider-github
+import { GitHubProvider } from "tinacms-gitprovider-github";
 
 const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === "true";
 const cosmosConnectionString = process.env.COSMOS_DB_CONNECTION_STRING;
+const githubToken = process.env.GITHUB_TOKEN;
 
 // Use Cosmos DB during build (for schema indexing) when connection string is available
 // Use local database for local development
 let database;
 
-if (isLocal || !cosmosConnectionString) {
+if (isLocal || !cosmosConnectionString || !githubToken) {
   // Local development: use local filesystem database
   database = createLocalDatabase();
 } else {
-  // Build/production: use Cosmos DB to index schema
-  const branch = process.env.GITHUB_BRANCH || process.env.HEAD || "main";
+  // CI build: use Cosmos DB to index schema with GitHub provider
+  const branch = process.env.GITHUB_BRANCH || "main";
+  const owner = process.env.GITHUB_OWNER || process.env.GITHUB_REPOSITORY?.split("/")[0];
+  const repo = process.env.GITHUB_REPO || process.env.GITHUB_REPOSITORY?.split("/")[1];
+
   database = createDatabase({
+    gitProvider: new GitHubProvider({
+      branch,
+      owner,
+      repo,
+      token: githubToken,
+    }),
     databaseAdapter: new MongodbLevel({
       collectionName: branch,
       dbName: process.env.COSMOS_DB_NAME || "tinacms",

--- a/tina/database.ts
+++ b/tina/database.ts
@@ -17,19 +17,16 @@ if (isLocal || !cosmosConnectionString || !githubToken) {
   database = createLocalDatabase();
 } else {
   // CI build: use Cosmos DB to index schema with GitHub provider
-  // Always use 'main' collection for schema (shared across all environments)
-  // GitHubProvider branch determines which content is read from Git
-  const branch = process.env.GITHUB_BRANCH || "main";
+  // Always use 'main' branch and collection for schema (shared across all environments)
   const owner = process.env.GITHUB_OWNER || process.env.GITHUB_REPOSITORY?.split("/")[0];
   const repo = process.env.GITHUB_REPO || process.env.GITHUB_REPOSITORY?.split("/")[1];
 
   console.log("[TinaCMS Build] Indexing schema to Cosmos DB");
-  console.log(`  Git Branch: ${branch}`);
-  console.log(`  Collection: main`);
+  console.log("  Branch: main, Collection: main");
 
   database = createDatabase({
     gitProvider: new GitHubProvider({
-      branch,
+      branch: "main",
       owner,
       repo,
       token: githubToken,


### PR DESCRIPTION
The build was using createLocalDatabase() which only stored the schema locally, not in Cosmos DB. At runtime, the API tried to read from Cosmos DB which had an empty 'main' collection, causing "GraphQL schema not found".

Changes:
- Update tina/database.ts to use Cosmos DB when connection string is set
- Add GITHUB_BRANCH env var to workflow for correct collection naming