### PR TITLE
Update station and equipment page with images

### DIFF
--- a/src/pages/about/fire-insurance.mdx
+++ b/src/pages/about/fire-insurance.mdx
@@ -122,17 +122,4 @@ To verify your specific property's protection class, contact WSRB directly:
 
 **Equipment Caches:** Henry, Johns, Pearl, and Spieden Islands
 
-## Emergency Apparatus
-
-* 6 - Type 1 Engines *(1000 gal tank, 1000gpm pump, dump tank)*
-* 1 - Quint Ladder *(500 gal tank, 1000gpm pump)*
-* 1 - Type 3 Brush Engine
-* 1 - Type 5 Brush Engine
-* 1 - Type 6 Brush Engine
-* 1 - Water Tender *(2500 gal tank, 500 gpm pump)*
-* 1 - Water Tender *(2000 gal tank, 500 gpm pump)*
-* 1 - Light Rescue
-* 1 - 25' Fast Response Boat *(500 gpm pump)*
-* 4 - Command Vehicles
-* 1 - Mobile Mechanic Vehicle
-* 1 - Utility Vehicle
+For detailed station information and apparatus inventory, see our [Stations & Equipment](/about/stations-equipment/) page.

--- a/src/pages/about/stations-equipment.mdx
+++ b/src/pages/about/stations-equipment.mdx
@@ -56,34 +56,29 @@ San Juan Island Fire & Rescue operates six stations on San Juan Island and maint
 
 ---
 
-### Outer Island Stations
+### Station 37 - Brown Island
 
-<table style="width: 100%; border-collapse: collapse;">
-<thead>
-<tr>
-<th style="padding: 12px 20px; text-align: center; border-bottom: 2px solid #ddd;">Station #</th>
-<th style="padding: 12px 20px; text-align: left; border-bottom: 2px solid #ddd;">Location</th>
-<th style="padding: 12px 20px; text-align: left; border-bottom: 2px solid #ddd;">Address</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style="padding: 10px 20px; text-align: center; border-bottom: 1px solid #eee;">37</td>
-<td style="padding: 10px 20px; border-bottom: 1px solid #eee;">Brown Island</td>
-<td style="padding: 10px 20px; border-bottom: 1px solid #eee;"><a href="https://www.google.com/maps/search/?api=1&query=8+Brown+Island+Friday+Harbor+WA">8 Brown Island</a></td>
-</tr>
-<tr>
-<td style="padding: 10px 20px; text-align: center; border-bottom: 1px solid #eee;">38</td>
-<td style="padding: 10px 20px; border-bottom: 1px solid #eee;">Stuart East</td>
-<td style="padding: 10px 20px; border-bottom: 1px solid #eee;"><a href="https://www.google.com/maps/search/?api=1&query=1378+Marine+Ln+Stuart+Island+WA">1378 Marine Ln</a></td>
-</tr>
-<tr>
-<td style="padding: 10px 20px; text-align: center; border-bottom: 1px solid #eee;">39</td>
-<td style="padding: 10px 20px; border-bottom: 1px solid #eee;">Stuart West</td>
-<td style="padding: 10px 20px; border-bottom: 1px solid #eee;"><a href="https://www.google.com/maps/search/?api=1&query=532+Reid+Harbor+Rd+Stuart+Island+WA">532 Reid Harbor Rd</a></td>
-</tr>
-</tbody>
-</table>
+**Brown Island**
+
+[8 Brown Island](https://www.google.com/maps/search/?api=1&query=8+Brown+Island+Friday+Harbor+WA)
+
+---
+
+### Station 38 - Stuart East
+
+**Stuart Island**
+
+[1378 Marine Ln](https://www.google.com/maps/search/?api=1&query=1378+Marine+Ln+Stuart+Island+WA)
+
+---
+
+### Station 39 - Stuart West
+
+**Stuart Island**
+
+[532 Reid Harbor Rd](https://www.google.com/maps/search/?api=1&query=532+Reid+Harbor+Rd+Stuart+Island+WA)
+
+---
 
 **Equipment Caches:** Henry, Johns, Pearl, and Spieden Islands
 

--- a/src/pages/about/stations-equipment.mdx
+++ b/src/pages/about/stations-equipment.mdx
@@ -1,5 +1,5 @@
 ---
-title: District Stations & Equipment
+title: Stations & Equipment
 nav_order: 3
 sidebar: ''
 ---
@@ -58,11 +58,32 @@ San Juan Island Fire & Rescue operates six stations on San Juan Island and maint
 
 ### Outer Island Stations
 
-| Station | Location | Address |
-|---------|----------|---------|
-| 37 | Brown Island | [8 Brown Island](https://www.google.com/maps/search/?api=1&query=8+Brown+Island+Friday+Harbor+WA) |
-| 38 | Stuart East | [1378 Marine Ln, Stuart Island](https://www.google.com/maps/search/?api=1&query=1378+Marine+Ln+Stuart+Island+WA) |
-| 39 | Stuart West | [532 Reid Harbor Rd, Stuart Island](https://www.google.com/maps/search/?api=1&query=532+Reid+Harbor+Rd+Stuart+Island+WA) |
+<table style="width: 100%; border-collapse: collapse;">
+<thead>
+<tr>
+<th style="padding: 12px 20px; text-align: center; border-bottom: 2px solid #ddd;">Station #</th>
+<th style="padding: 12px 20px; text-align: left; border-bottom: 2px solid #ddd;">Location</th>
+<th style="padding: 12px 20px; text-align: left; border-bottom: 2px solid #ddd;">Address</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="padding: 10px 20px; text-align: center; border-bottom: 1px solid #eee;">37</td>
+<td style="padding: 10px 20px; border-bottom: 1px solid #eee;">Brown Island</td>
+<td style="padding: 10px 20px; border-bottom: 1px solid #eee;"><a href="https://www.google.com/maps/search/?api=1&query=8+Brown+Island+Friday+Harbor+WA">8 Brown Island</a></td>
+</tr>
+<tr>
+<td style="padding: 10px 20px; text-align: center; border-bottom: 1px solid #eee;">38</td>
+<td style="padding: 10px 20px; border-bottom: 1px solid #eee;">Stuart East</td>
+<td style="padding: 10px 20px; border-bottom: 1px solid #eee;"><a href="https://www.google.com/maps/search/?api=1&query=1378+Marine+Ln+Stuart+Island+WA">1378 Marine Ln</a></td>
+</tr>
+<tr>
+<td style="padding: 10px 20px; text-align: center; border-bottom: 1px solid #eee;">39</td>
+<td style="padding: 10px 20px; border-bottom: 1px solid #eee;">Stuart West</td>
+<td style="padding: 10px 20px; border-bottom: 1px solid #eee;"><a href="https://www.google.com/maps/search/?api=1&query=532+Reid+Harbor+Rd+Stuart+Island+WA">532 Reid Harbor Rd</a></td>
+</tr>
+</tbody>
+</table>
 
 **Equipment Caches:** Henry, Johns, Pearl, and Spieden Islands
 
@@ -74,15 +95,15 @@ San Juan Island Fire & Rescue operates six stations on San Juan Island and maint
 
 ### Apparatus Inventory
 
-* 6 - Type 1 Engines *(1000 gal tank, 1000gpm pump, dump tank)*
-* 1 - Quint Ladder *(500 gal tank, 1000gpm pump)*
-* 1 - Type 3 Brush Engine
-* 1 - Type 5 Brush Engine
+* 6 - Type 1 Engines **(1000 gal tank, 1000gpm pump, dump tank)**
+* 1 - Quint Ladder **(500 gal tank, 1000gpm pump)**
+* 2 - Type 3 Brush Engines
+* 2 - Type 5 Brush Engines
 * 1 - Type 6 Brush Engine
-* 1 - Water Tender *(2500 gal tank, 500 gpm pump)*
-* 1 - Water Tender *(2000 gal tank, 500 gpm pump)*
+* 1 - Water Tender **(2500 gal tank, 500 gpm pump)**
+* 1 - Water Tender **(2000 gal tank, 500 gpm pump)**
 * 1 - Light Rescue
-* 1 - 25' Fast Response Boat *(500 gpm pump)*
+* 1 - 25' Fast Response Boat **(500 gpm pump)**
 * 4 - Command Vehicles
 * 1 - Mobile Mechanic Vehicle
 * 1 - Utility Vehicle

--- a/src/pages/about/stations-equipment.mdx
+++ b/src/pages/about/stations-equipment.mdx
@@ -1,63 +1,88 @@
 ---
 title: District Stations & Equipment
-nav_hidden: true
+nav_order: 3
 sidebar: ''
 ---
 
-## Stations:
+San Juan Island Fire & Rescue operates six stations on San Juan Island and maintains equipment caches on surrounding islands. For fire insurance rating information, see our [Fire Insurance](/about/fire-insurance/) page.
 
-![](/assets/media/s31.png "Station 31")
+## Stations
 
-#### Station 31
+![](/assets/media/s31.jpeg "Station 31 - Headquarters")
 
-Friday Harbor **(staffed 24/7)**
+### Station 31 - Headquarters
 
-![](/assets/media/s32.png "Station 32")
+**Staffed 24/7**
 
-#### Station 32
+[1011 Mullis St, Friday Harbor, WA 98250](https://www.google.com/maps/search/?api=1&query=1011+Mullis+St+Friday+Harbor+WA+98250)
 
-Cap San Juan
+---
 
-![](/assets/media/s33.png "Station 33")
+![](/assets/media/s32.jpeg "Station 32 - Cape San Juan")
 
-#### Station 33
+### Station 32 - Cape San Juan
 
-Bailer Hill / Little Mnt.
+[488 Island Dr, Friday Harbor, WA 98250](https://www.google.com/maps/search/?api=1&query=488+Island+Dr+Friday+Harbor+WA+98250)
 
-![](/assets/media/s34.png "Station 34")
+---
 
-#### Station 34
+![](/assets/media/s33.jpeg "Station 33 - Little Mountain")
 
-Sunset Point / West Side
+### Station 33 - Little Mountain
 
-![](/assets/media/s35.png "Station 35")
+[3189 Bailer Hill Rd, Friday Harbor, WA 98250](https://www.google.com/maps/search/?api=1&query=3189+Bailer+Hill+Rd+Friday+Harbor+WA+98250)
 
-#### Station 35
+---
 
-Roche Harbor
+![](/assets/media/s34.jpeg "Station 34 - Sunset Point")
 
-#### Station 36
+### Station 34 - Sunset Point
 
-Eagle Crest
+[5174 West Side Rd, Friday Harbor, WA 98250](https://www.google.com/maps/search/?api=1&query=5174+West+Side+Rd+Friday+Harbor+WA+98250)
 
-### Equipment Caches
+---
 
-Exist on: Brown, Henry, Johns, Pearl, and Stuart Islands
+![](/assets/media/s35.jpeg "Station 35 - Roche Harbor")
+
+### Station 35 - Roche Harbor
+
+[32 Cessna Ave, Friday Harbor, WA 98250](https://www.google.com/maps/search/?api=1&query=32+Cessna+Ave+Friday+Harbor+WA+98250)
+
+---
+
+### Station 36 - Eagle Crest
+
+[367 Three Corner Lake Rd, Friday Harbor, WA 98250](https://www.google.com/maps/search/?api=1&query=367+Three+Corner+Lake+Rd+Friday+Harbor+WA+98250)
+
+---
+
+### Outer Island Stations
+
+| Station | Location | Address |
+|---------|----------|---------|
+| 37 | Brown Island | [8 Brown Island](https://www.google.com/maps/search/?api=1&query=8+Brown+Island+Friday+Harbor+WA) |
+| 38 | Stuart East | [1378 Marine Ln, Stuart Island](https://www.google.com/maps/search/?api=1&query=1378+Marine+Ln+Stuart+Island+WA) |
+| 39 | Stuart West | [532 Reid Harbor Rd, Stuart Island](https://www.google.com/maps/search/?api=1&query=532+Reid+Harbor+Rd+Stuart+Island+WA) |
+
+**Equipment Caches:** Henry, Johns, Pearl, and Spieden Islands
 
 ## Equipment
 
 ![](/assets/media/type-1-engine.jpeg "Type 1 Engine")
-Type 1 Engine
 
-* 6 - Type 1 Engines `(1000 gal tank, 1000gpm pump, dump tank)`
-* 1 - Quint Ladder `(500 gal tank, 1000gpm pump)`
+**Type 1 Engine**
+
+### Apparatus Inventory
+
+* 6 - Type 1 Engines *(1000 gal tank, 1000gpm pump, dump tank)*
+* 1 - Quint Ladder *(500 gal tank, 1000gpm pump)*
 * 1 - Type 3 Brush Engine
 * 1 - Type 5 Brush Engine
 * 1 - Type 6 Brush Engine
-* 1 - Water Tender `(2500 gal tank, 500 gpm pump)`
-* 1 - Water Tender `(2000 gal tank, 500 gpm pump)`
+* 1 - Water Tender *(2500 gal tank, 500 gpm pump)*
+* 1 - Water Tender *(2000 gal tank, 500 gpm pump)*
 * 1 - Light Rescue
-* 1 - 25' Fast Response Boat `(500 gpm pump)`
+* 1 - 25' Fast Response Boat *(500 gpm pump)*
 * 4 - Command Vehicles
 * 1 - Mobile Mechanic Vehicle
 * 1 - Utility Vehicle


### PR DESCRIPTION
- Fix broken image links (changed .png to .jpeg)
- Add station addresses with Google Maps links
- Add outer island stations (37-39) info
- Make page visible in navigation (nav_order: 3)
- Add link to fire insurance page