### PR TITLE
Simplify incident page stats and details

### DIFF
--- a/src/_includes/call-stats-widget.njk
+++ b/src/_includes/call-stats-widget.njk
@@ -107,23 +107,45 @@
       </td>
     </tr>
     <tr class="{{ cls.next() }}">
-      <th>
+      <th rowspan=4>
         Incident Types
       </th>
       <td>
-        {{ stats.incident_stats.types.medical_rescue }} Medical Assists<br>
-        {{ stats.incident_stats.types.fire }} Fire<br>
-        {{ stats.incident_stats.types.downgraded }} Downgraded<br>
-        {{ stats.incident_stats.types.cancelled }} Cancelled
+        {{ stats.incident_stats.types.medical_rescue }}
+        <aside>Medical Assists</aside>
       </td>
     </tr>
     <tr class="{{ cls.next() }}">
-      <th>
+      <td>
+        {{ stats.incident_stats.types.fire }}
+        <aside>Fire</aside>
+      </td>
+    </tr>
+    <tr class="{{ cls.next() }}">
+      <td>
+        {{ stats.incident_stats.types.downgraded }}
+        <aside>Downgraded</aside>
+      </td>
+    </tr>
+    <tr class="{{ cls.next() }}">
+      <td>
+        {{ stats.incident_stats.types.cancelled }}
+        <aside>Cancelled</aside>
+      </td>
+    </tr>
+    <tr class="{{ cls.next() }}">
+      <th rowspan=2>
         Time of Day
       </th>
       <td>
-        {{ stats.incident_stats.num_daytime_incidents }} daytime<br>
-        {{ stats.incident_stats.num_nighttime_incidents }} nighttime
+        {{ stats.incident_stats.num_daytime_incidents }}
+        <aside>Daytime</aside>
+      </td>
+    </tr>
+    <tr class="{{ cls.next() }}">
+      <td>
+        {{ stats.incident_stats.num_nighttime_incidents }}
+        <aside>Nighttime</aside>
       </td>
     </tr>
     <tr class="{{ cls.next() }}">

--- a/src/_includes/call-stats-widget.njk
+++ b/src/_includes/call-stats-widget.njk
@@ -5,7 +5,7 @@
         <svg><use xlink:href='#stats' /></svg>
         <div>
           <h4>
-            SJIF&R Statistics
+            Response Statistics
           </h4>
           <div class="timeframe">
             Last 30 days
@@ -27,7 +27,7 @@
     <tr class="{{ cls.next() }}">
       <th>
         Calls
-        <aside>Last 365 Days</aside>
+        <aside>Last 365 days</aside>
       </th>
       <td>
         {{ stats.incident_stats.num_incidents_last_365_days | formatNumber }}
@@ -36,7 +36,7 @@
     <tr class="{{ cls.next() }}">
       <th>
         Reaction Time
-        <aside>Seconds</aside>
+        <aside>Median seconds</aside>
       </th>
       <td>
         {{ stats.unit_time_stats.first_unit_reaction.median }}
@@ -45,15 +45,15 @@
     <tr class="{{ cls.next() }}">
       <th rowspan=3>
         Travel Time
-        <aside>Minutes (% of calls)</aside>
+        <aside>Median minutes</aside>
       </th>
       <td>
         {% if stats.region_stats.central and stats.region_stats.central.num_incidents > 0 -%}
           {{ (stats.region_stats.central.unit_travel_time.median/60) | round(1) }}
-          <aside>Central ({{((stats.region_stats.central.num_incidents/stats.incident_stats.num_incidents) * 100) | round }}%)</aside>
+          <aside>Central</aside>
         {% else %}
            --
-          <aside>Central (0%)</aside>
+          <aside>Central</aside>
         {% endif -%}
       </td>
     </tr>
@@ -61,10 +61,10 @@
       <td>
         {% if stats.region_stats.south and stats.region_stats.south.num_incidents > 0 -%}
           {{ (stats.region_stats.south.unit_travel_time.median/60) | round(1) }}
-          <aside>South ({{((stats.region_stats.south.num_incidents/stats.incident_stats.num_incidents) * 100) | round }}%)</aside>
+          <aside>South</aside>
         {% else %}
            --
-          <aside>South (0%)</aside>
+          <aside>South</aside>
         {% endif -%}
       </td>
     </tr>
@@ -72,17 +72,17 @@
       <td>
         {% if stats.region_stats.north and stats.region_stats.north.num_incidents > 0 -%}
           {{ (stats.region_stats.north.unit_travel_time.median/60) | round(1) }}
-          <aside>North ({{((stats.region_stats.north.num_incidents/stats.incident_stats.num_incidents) * 100) | round }}%)</aside>
+          <aside>North</aside>
         {% else %}
            --
-          <aside>North (0%)</aside>
+          <aside>North</aside>
         {% endif -%}
       </td>
     </tr>
     <tr class="{{ cls.next() }}">
       <th>
         Responder Time on Calls
-        <aside>Minutes</aside>
+        <aside>Total minutes</aside>
       </th>
       <td>
         {{ (stats.personnel_stats.time_on_incidents.sum/60) | round | formatNumber }}

--- a/src/_includes/call-stats-widget.njk
+++ b/src/_includes/call-stats-widget.njk
@@ -96,6 +96,45 @@
         {{ stats.personnel_stats.num_unique_responders }}
       </td>
     </tr>
+    {% if page.url !== '/' %}
+    <tr class="{{ cls.next() }}">
+      <th>
+        Responders per Call
+        <aside>Median</aside>
+      </th>
+      <td>
+        {{ stats.personnel_stats.num_per_incidents.median | round(0, 'ceil') }}
+      </td>
+    </tr>
+    <tr class="{{ cls.next() }}">
+      <th>
+        Incident Types
+      </th>
+      <td>
+        {{ stats.incident_stats.types.medical_rescue }} Medical Assists<br>
+        {{ stats.incident_stats.types.fire }} Fire<br>
+        {{ stats.incident_stats.types.downgraded }} Downgraded<br>
+        {{ stats.incident_stats.types.cancelled }} Cancelled
+      </td>
+    </tr>
+    <tr class="{{ cls.next() }}">
+      <th>
+        Time of Day
+      </th>
+      <td>
+        {{ stats.incident_stats.num_daytime_incidents }} daytime<br>
+        {{ stats.incident_stats.num_nighttime_incidents }} nighttime
+      </td>
+    </tr>
+    <tr class="{{ cls.next() }}">
+      <th>
+        Simultaneous Calls
+      </th>
+      <td>
+        {{ stats.incident_stats.num_overlapping_incidents }}
+      </td>
+    </tr>
+    {% endif %}
   </tbody>
   {% if page.url === '/' %}
     <tfoot class="widget__foot">

--- a/src/_includes/call-stats-widget.njk
+++ b/src/_includes/call-stats-widget.njk
@@ -111,14 +111,14 @@
         Incident Types
       </th>
       <td>
-        {{ stats.incident_stats.types.medical_rescue }}
-        <aside>Medical Assists</aside>
+        {{ stats.incident_stats.types.fire }}
+        <aside>Fire</aside>
       </td>
     </tr>
     <tr class="{{ cls.next() }}">
       <td>
-        {{ stats.incident_stats.types.fire }}
-        <aside>Fire</aside>
+        {{ stats.incident_stats.types.medical_rescue }}
+        <aside>Medical Assists</aside>
       </td>
     </tr>
     <tr class="{{ cls.next() }}">

--- a/src/_includes/call-stats-widget.njk
+++ b/src/_includes/call-stats-widget.njk
@@ -36,7 +36,7 @@
     <tr class="{{ cls.next() }}">
       <th>
         Reaction Time
-        <aside>Median seconds</aside>
+        <aside>Seconds</aside>
       </th>
       <td>
         {{ stats.unit_time_stats.first_unit_reaction.median }}
@@ -45,15 +45,15 @@
     <tr class="{{ cls.next() }}">
       <th rowspan=3>
         Travel Time
-        <aside>Median minutes</aside>
+        <aside>Minutes (% of calls)</aside>
       </th>
       <td>
         {% if stats.region_stats.central and stats.region_stats.central.num_incidents > 0 -%}
           {{ (stats.region_stats.central.unit_travel_time.median/60) | round(1) }}
-          <aside>Central</aside>
+          <aside>Central ({{((stats.region_stats.central.num_incidents/stats.incident_stats.num_incidents) * 100) | round }}%)</aside>
         {% else %}
            --
-          <aside>Central</aside>
+          <aside>Central (0%)</aside>
         {% endif -%}
       </td>
     </tr>
@@ -61,10 +61,10 @@
       <td>
         {% if stats.region_stats.south and stats.region_stats.south.num_incidents > 0 -%}
           {{ (stats.region_stats.south.unit_travel_time.median/60) | round(1) }}
-          <aside>South</aside>
+          <aside>South ({{((stats.region_stats.south.num_incidents/stats.incident_stats.num_incidents) * 100) | round }}%)</aside>
         {% else %}
            --
-          <aside>South</aside>
+          <aside>South (0%)</aside>
         {% endif -%}
       </td>
     </tr>
@@ -72,17 +72,17 @@
       <td>
         {% if stats.region_stats.north and stats.region_stats.north.num_incidents > 0 -%}
           {{ (stats.region_stats.north.unit_travel_time.median/60) | round(1) }}
-          <aside>North</aside>
+          <aside>North ({{((stats.region_stats.north.num_incidents/stats.incident_stats.num_incidents) * 100) | round }}%)</aside>
         {% else %}
            --
-          <aside>North</aside>
+          <aside>North (0%)</aside>
         {% endif -%}
       </td>
     </tr>
     <tr class="{{ cls.next() }}">
       <th>
         Responder Time on Calls
-        <aside>Total minutes</aside>
+        <aside>Minutes</aside>
       </th>
       <td>
         {{ (stats.personnel_stats.time_on_incidents.sum/60) | round | formatNumber }}

--- a/src/pages/about/incidents-body.mdx
+++ b/src/pages/about/incidents-body.mdx
@@ -7,39 +7,24 @@ contentFor: incidents
 
 # Incidents
 
-Our purpose in emergency services is crystal clear: save lives, protect property, and promote public safety through prevention and education.
+We believe in transparency. These statistics show our response activity and help us identify ways to better serve San Juan Island.
 
-Collecting and using data—whether from calls, our internal trainings, or public education events—can help us provide improved AND more cost-effective services to our community.  It can show what is working well, what isn’t, what is changing over time, and how effective intentional changes have been in meeting our purpose.
+## What the Numbers Mean
 
-However, data is not the be-all and end-all.  It is an important tool, but just one of a handful we use to see how we’re doing and where we can improve.
+- **Calls:** Every 911 call in our district or mutual aid request we respond to.
+- **Reaction Time:** How quickly we get our crew ready and vehicles moving after dispatch notifies us.
+- **Travel Time:** How long it takes to reach the scene once we're on the road. Broken out by region:
+  - *Central:* Friday Harbor area north to around Egg Lake Road
+  - *South:* South and west of town, along Cattle Point and Bailer Hill
+  - *North:* North of Egg Lake Road out to Roche Harbor
+- **Responder Time on Calls:** Total time our responders spent on active incidents.
+- **Unique Responders:** Number of individual responders who responded to one or more calls.
 
+All times shown are the median (typical) value over the past 30 days. Data is updated daily from [ESO](https://www.eso.com/), our incident reporting system, and only includes completed incidents.
 
-## Key Points
+## More Information
 
-* A call, or incident, is anytime dispatch receives a 911 call that is in our district or and assistance request from beyond our district.
-* These numbers represent the last 30 days of calls except where we also display the number of calls in the past 365 days.
-* This data is recomputed every morning and comes directly from [ESO]( https://www.eso.com/), our incident and medical reporting software.
-* Only incidents which are finished and have had all the paperwork finalized are included.  The vast majority of incident reports are finished within a few hours, though larger, more complicated, multi-day incident reports, such as for wildland fires, may take upwards of 3 days to complete.
-* All time statistics are the median, or the typical 50%, over the past 30 days.
-* Times are logged by dispatch from communication over a single radio frequency, which can cause the logging of times to be delayed if the airway is clogged with voice traffic.
-* It’s important to state that this data is provided in good faith and as-is, as defined in the [disclaimer](/disclaimer/).
+This data is provided in good faith as described in our [disclaimer](/disclaimer/). For detailed data and methodology, visit our [GitHub repository](https://github.com/sjifire/website).
 
-
-## Definitions
-
-* **Responders:**
-  * **Responder Time on Calls:** This is the total amount of time your responders have spent on active calls in their community in the past 30 days.  Some scenes can get complex with responders and apparatus coming and going, and this number tracks that down to the level of the individual responder.  It doesn’t include return travel to the station, clean-up time, equipment maintenance time, or training hours.
-  * **Unique Responders:**  How many responders responded to one or more incidents in the past 30 days.
-* **Incident Times:**
-  * **Reaction Time:** This is the time from when dispatch tells us they received a 911 call to when responders are dressed in the appropriate equipment, vehicle has been inspected with a full walk-around, all responders are buckled in their seats, and the vehicle is moving forward.  We don’t want to travel with open doors or coffee mugs on the rear tailboard!  And the days of just hopping into or on a moving vehicle are long gone.
-  * **Travel Time:**  The amount of time from when an apparatus is moving to when it arrives on scene.  These times are broken out based upon the incident regions, which roughly correspond to:
-    * **Central:** The central part of the island, from a rough line around Egg Lake Road to Friday Harbor.
-    * **North:** North of Egg Lake Road out to Roche Harbor and beyond.
-    * **South:** South and West of Town, along Cattle Pt. Rd. and Bailer Hill.
-
-
-The code for the website and statistics reporting can be found on [SJIF&R's Github repository](https://github.com/sjifire/website) [[data](https://github.com/sjifire/website/blob/main/src/_data/stats.json), [code](https://github.com/sjifire/website/blob/main/bin/eso_stats_scrapper.js)].
-
-
-SJIF&R follows a national standard around logging and grouping of incident data, and this data is integrated into the regional and national medical and incident reporting systems, such as the [National Fire Incident Reporting System](https://www.usfa.fema.gov/nfirs/).
+We follow the [National Fire Incident Reporting System](https://www.usfa.fema.gov/nfirs/) standards for incident documentation.
 

--- a/src/pages/about/incidents-body.mdx
+++ b/src/pages/about/incidents-body.mdx
@@ -17,6 +17,10 @@ We believe in transparency. These statistics show our response activity and help
   - *North:* North of Egg Lake Road out to Roche Harbor
 - **Responder Time on Calls:** Total time our responders spent on active incidents.
 - **Unique Responders:** Number of individual responders who responded to one or more calls.
+- **Responders per Call:** Typical number of responders at each incident.
+- **Incident Types:** Breakdown of calls by category—Medical Assists, Fire, Downgraded (reduced priority), and Cancelled.
+- **Time of Day:** When calls occur—daytime (6am–6pm) or nighttime.
+- **Simultaneous Calls:** How often we handled multiple incidents at once.
 
 All times shown are the median (typical) value over the past 30 days. Data is updated daily from [ESO](https://www.eso.com/), our incident reporting system, and only includes completed incidents.
 

--- a/src/pages/about/incidents-body.mdx
+++ b/src/pages/about/incidents-body.mdx
@@ -5,7 +5,7 @@ tags: content-include
 contentFor: incidents
 ---
 
-We believe in transparency. These statistics show our response activity and help us identify ways to better serve San Juan Island.
+We believe in transparency. These statistics show our response activity and help us identify ways to better serve our district.
 
 ## What the Numbers Mean
 

--- a/src/pages/about/incidents-body.mdx
+++ b/src/pages/about/incidents-body.mdx
@@ -5,8 +5,6 @@ tags: content-include
 contentFor: incidents
 ---
 
-# Incidents
-
 We believe in transparency. These statistics show our response activity and help us identify ways to better serve San Juan Island.
 
 ## What the Numbers Mean

--- a/src/pages/about/incidents.njk
+++ b/src/pages/about/incidents.njk
@@ -20,4 +20,31 @@ layout: false
     {{ item.content | processStyledImages | safe }}
   {% endif %}
 {% endfor %}
+
+<h2>Additional Statistics</h2>
+<table class="stats-table">
+  <tbody>
+    <tr>
+      <th>Incident Types</th>
+      <td>
+        {{ stats.incident_stats.types.medical_rescue }} Medical Assists,
+        {{ stats.incident_stats.types.fire }} Fire,
+        {{ stats.incident_stats.types.downgraded }} Downgraded,
+        {{ stats.incident_stats.types.cancelled }} Cancelled
+      </td>
+    </tr>
+    <tr>
+      <th>Time of Day</th>
+      <td>{{ stats.incident_stats.num_daytime_incidents }} daytime, {{ stats.incident_stats.num_nighttime_incidents }} nighttime</td>
+    </tr>
+    <tr>
+      <th>Responders per Call</th>
+      <td>{{ stats.personnel_stats.num_per_incidents.median | round(0, 'ceil') }} (median)</td>
+    </tr>
+    <tr>
+      <th>Simultaneous Calls</th>
+      <td>{{ stats.incident_stats.num_overlapping_incidents }}</td>
+    </tr>
+  </tbody>
+</table>
 {% endblock %}

--- a/src/pages/about/incidents.njk
+++ b/src/pages/about/incidents.njk
@@ -20,31 +20,4 @@ layout: false
     {{ item.content | processStyledImages | safe }}
   {% endif %}
 {% endfor %}
-
-<h2>Additional Statistics</h2>
-<table class="stats-table">
-  <tbody>
-    <tr>
-      <th>Incident Types</th>
-      <td>
-        {{ stats.incident_stats.types.medical_rescue }} Medical Assists,
-        {{ stats.incident_stats.types.fire }} Fire,
-        {{ stats.incident_stats.types.downgraded }} Downgraded,
-        {{ stats.incident_stats.types.cancelled }} Cancelled
-      </td>
-    </tr>
-    <tr>
-      <th>Time of Day</th>
-      <td>{{ stats.incident_stats.num_daytime_incidents }} daytime, {{ stats.incident_stats.num_nighttime_incidents }} nighttime</td>
-    </tr>
-    <tr>
-      <th>Responders per Call</th>
-      <td>{{ stats.personnel_stats.num_per_incidents.median | round(0, 'ceil') }} (median)</td>
-    </tr>
-    <tr>
-      <th>Simultaneous Calls</th>
-      <td>{{ stats.incident_stats.num_overlapping_incidents }}</td>
-    </tr>
-  </tbody>
-</table>
 {% endblock %}


### PR DESCRIPTION
- Reduce stats widget from 8 metrics to 4 key metrics: calls (30/365 days), reaction time, and travel time
- Remove regional travel time breakdown and internal metrics (responder time, unique responders)
- Streamline page content with concise explanations
- Maintain transparency with links to data source and disclaimer