### PR TITLE
Add retry logic for Azure deployment failures

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -67,6 +67,35 @@ jobs:
 
       - name: Deploy to Azure
         id: builddeploy
+        continue-on-error: true
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_JOLLY_MOSS_0DB15021E }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "_site"
+          api_location: "api"
+          output_location: ""
+          skip_app_build: true
+          github_id_token: ${{ steps.idtoken.outputs.result }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPO: ${{ github.event.repository.name }}
+          AAD_CLIENT_ID: ${{ secrets.AAD_CLIENT_ID }}
+          AAD_CLIENT_SECRET: ${{ secrets.AAD_CLIENT_SECRET }}
+          ALLOWED_EDITOR_GROUPS: ${{ secrets.ALLOWED_EDITOR_GROUPS }}
+          COSMOS_DB_CONNECTION_STRING: ${{ secrets.COSMOS_DB_CONNECTION_STRING }}
+          COSMOS_DB_NAME: ${{ secrets.COSMOS_DB_NAME }}
+          TINA_PUBLIC_IS_LOCAL: "false"
+
+      - name: Wait before retry
+        if: steps.builddeploy.outcome == 'failure'
+        run: sleep 30
+
+      - name: Deploy to Azure (retry)
+        id: builddeploy_retry
+        if: steps.builddeploy.outcome == 'failure'
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_JOLLY_MOSS_0DB15021E }}


### PR DESCRIPTION
If the initial deploy fails, wait 30 seconds and retry once. This helps handle transient network or Azure service issues.