### PR TITLE
Restore burn widget to burn permits sidebar

### DIFF
--- a/src/_includes/page.njk
+++ b/src/_includes/page.njk
@@ -18,6 +18,11 @@
       </div>
 
       <aside class="l-grid__sidebar">
+        {% if include_burn_widget %}
+          <div class="sidebar-block">
+            {% include "burn-status-widget.njk" %}
+          </div>
+        {% endif %}
         {% if sidebar %}
           {{ sidebar | markdownify | processStyledImages | safe }}
         {% endif %}

--- a/src/pages/services/burn-permits.mdx
+++ b/src/pages/services/burn-permits.mdx
@@ -1,9 +1,8 @@
 ---
 title: Burn Permits
 nav_order: 2
+include_burn_widget: true
 sidebar: >
-  {% include "burn-status-widget.njk" %}
-
   <div class="sidebar-block">
     <h4 class="sidebar__heading">Get a Burn Permit</h4>
     <p>Purchase residential permits online from the San Juan County Fire Marshal.</p>


### PR DESCRIPTION
Add include_burn_widget frontmatter flag to page.njk layout so MDX pages can include the burn-status-widget without converting to NJK. The previous {% include %} syntax in sidebar frontmatter didn't work because sidebar content only goes through markdownify, not Nunjucks.