### PR TITLE
Simplify TinaCMS site config fields

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -65,7 +65,7 @@ module.exports = function(eleventyConfig) {
 
   // Next meeting date filter for governance page
   eleventyConfig.addFilter("nextMeetingDate", function(schedule, override) {
-    return getNextMeeting(schedule, override, siteData.address.timezone);
+    return getNextMeeting(schedule, override, siteData.timezone);
   });
 
 

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -4,16 +4,7 @@
   "cloudinaryRootUrl": "https://res.cloudinary.com/san-juan-fire-district-3",
   "site_name": "San Juan Island Fire and Rescue",
   "site_desc": "San Juan Island Fire and Rescue provides fire, rescue, and marine emergency services to Friday Harbor and multiple islands within San Juan County, WA.",
-  "formal_site_name": "San Juan County Fire District #3",
-  "address": {
-    "street": "1011 Mullis Street",
-    "city": "Friday Harbor",
-    "state": "WA",
-    "zip": "98250",
-    "phone": "360-378-5334",
-    "timezone": "America/Los_Angeles",
-    "map": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4248.38934322883!2d-123.02445167834331!3d48.523208538641285!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x548f7eed6a631a9f%3A0x943116e04dc9aac3!2sSan%20Juan%20Fire%20Protection%20District!5e0!3m2!1sen!2sus!4v1633656761107!5m2!1sen!2sus"
-  },
+  "timezone": "America/Los_Angeles",
   "opengraph_image": "sjifire-logo-clear.png",
   "enable_cloudinary_rewrites": false
 }

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -220,11 +220,6 @@ export default defineConfig({
           },
           {
             type: "string",
-            name: "formal_site_name",
-            label: "Formal Site Name",
-          },
-          {
-            type: "string",
             name: "site_desc",
             label: "Site Description",
             ui: {
@@ -258,50 +253,15 @@ export default defineConfig({
           },
           {
             type: "string",
-            name: "opengraph_image",
-            label: "OpenGraph Image Filename",
+            name: "timezone",
+            label: "Timezone",
             ui: { component: () => null },
           },
           {
-            type: "object",
-            name: "address",
-            label: "Address",
+            type: "string",
+            name: "opengraph_image",
+            label: "OpenGraph Image Filename",
             ui: { component: () => null },
-            fields: [
-              {
-                type: "string",
-                name: "street",
-                label: "Street",
-              },
-              {
-                type: "string",
-                name: "city",
-                label: "City",
-              },
-              {
-                type: "string",
-                name: "state",
-                label: "State",
-              },
-              {
-                type: "string",
-                name: "zip",
-                label: "ZIP Code",
-              },
-              {
-                type: "string",
-                name: "phone",
-                label: "Phone",
-              },
-              {
-                type: "string",
-                name: "map",
-                label: "Google Maps Embed URL",
-                ui: {
-                  component: "textarea",
-                },
-              },
-            ],
           },
         ],
       },

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -231,35 +231,42 @@ export default defineConfig({
               component: "textarea",
             },
           },
+          // Hidden fields - not user-configurable
           {
             type: "string",
             name: "prodUrl",
             label: "Production URL",
+            ui: { component: () => null },
           },
           {
             type: "string",
             name: "cloudinaryFetchUrl",
             label: "Cloudinary Site ID",
+            ui: { component: () => null },
           },
           {
             type: "string",
             name: "cloudinaryRootUrl",
             label: "Cloudinary Root URL",
+            ui: { component: () => null },
           },
           {
             type: "boolean",
             name: "enable_cloudinary_rewrites",
             label: "Enable Cloudinary Rewrites",
+            ui: { component: () => null },
           },
           {
             type: "string",
             name: "opengraph_image",
             label: "OpenGraph Image Filename",
+            ui: { component: () => null },
           },
           {
             type: "object",
             name: "address",
             label: "Address",
+            ui: { component: () => null },
             fields: [
               {
                 type: "string",

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
     collections: [
       {
         name: "configBurnStatus",
-        label: "Config: Burn Status",
+        label: "Burn Status",
         path: "src/_data",
         format: "json",
         match: {
@@ -119,7 +119,7 @@ export default defineConfig({
       },
       {
         name: "configNavigation",
-        label: "Config: Navigation",
+        label: "Menu Structure",
         path: "src/_data",
         format: "json",
         match: {
@@ -199,7 +199,7 @@ export default defineConfig({
       },
       {
         name: "configSite",
-        label: "Config: Site",
+        label: "Site Identity",
         path: "src/_data",
         format: "json",
         match: {
@@ -267,7 +267,7 @@ export default defineConfig({
       },
       {
         name: "configGovernanceMeeting",
-        label: "Config: Governance Meeting",
+        label: "Board Meeting",
         path: "src/_data",
         format: "json",
         match: {
@@ -407,7 +407,7 @@ export default defineConfig({
       },
       {
         name: "configPersonnel",
-        label: "Config: Personnel",
+        label: "Personnel",
         path: "src/pages/about",
         format: "mdx",
         match: {


### PR DESCRIPTION
Only site_name, formal_site_name, and site_desc are now visible to editors. Technical settings (prodUrl, Cloudinary, opengraph, address) are hidden from the CMS UI.