### PR TITLE
feat: add quick links section to homepage

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1582,6 +1582,60 @@ select.form-control:focus::-ms-value {
   fill: var(--yellow);
 }
 
+/* Quick Actions Box */
+.quick-actions-box {
+  margin-bottom: 1.5rem;
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 0 8px rgb(0, 0, 0, 0.2);
+  padding: 30px;
+}
+
+.quick-actions-box__header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.025rem;
+  line-height: 1;
+  color: var(--bright-red);
+  text-transform: uppercase;
+}
+
+.quick-actions-box__header h4 {
+  margin: 0;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+}
+
+.quick-actions-box__body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.quick-actions-box__body .btn {
+  flex: 1 1 auto;
+  justify-content: center;
+  min-width: 140px;
+}
+
+.quick-actions-box__body .btn svg {
+  fill: currentcolor;
+}
+
+@media (width <= 600px) {
+  .quick-actions-box__body {
+    flex-direction: column;
+  }
+
+  .quick-actions-box__body .btn {
+    width: 100%;
+  }
+}
+
 /* Styled Images (TinaCMS) */
 .block-content .styled-image {
   margin: 1.5rem 0;

--- a/src/pages/homepage.njk
+++ b/src/pages/homepage.njk
@@ -12,6 +12,25 @@ header_image_source:
 {% block content %}
   <div class="l-grid l-grid--2col flipped">
     <div class="l-grid__main block-content">
+      <section class="quick-actions-box">
+        <header class="quick-actions-box__header">
+          <h4>Quick Links</h4>
+        </header>
+        <nav class="quick-actions-box__body" aria-label="Quick links">
+          <a href="/services/burn-permits/" class="btn btn-primary">
+            <svg><use xlink:href="#flame"></use></svg>
+            Burn Permits
+          </a>
+          <a href="/about/fire-insurance/" class="btn btn-primary">
+            <svg><use xlink:href="#fact-check"></use></svg>
+            Fire Insurance Info
+          </a>
+          <a href="/about/governance/" class="btn btn-primary">
+            <svg><use xlink:href="#stats"></use></svg>
+            Governance
+          </a>
+        </nav>
+      </section>
       <ul class="l-grid l-grid--auto">
         {% for post in posts | reverse | limit(homepage.number_news_stories) %}
           <li class="card">


### PR DESCRIPTION
## Summary
- Adds a "Quick Links" section above the news posts on the homepage
- Links to Burn Permits, Fire Insurance Info, and Governance pages
- Styled as a card with white background, matching existing post card design
- Header uses red uppercase label style matching post type headers (e.g., "Announcement", "News")

addresses part of #14 

## Test plan
- [ ] Verify quick links section appears above news posts on homepage
- [ ] Confirm links navigate to correct pages
- [ ] Check responsive behavior on mobile (buttons stack vertically)
- [ ] Verify styling matches existing card/post patterns
