### PR TITLE
fix: use c_limit instead of c_fill for carousel images

### DIFF
--- a/src/pages/homepage.njk
+++ b/src/pages/homepage.njk
@@ -68,7 +68,7 @@ header_image_source:
           <div class="carousel__slides" aria-live="polite">
             {% for img in homepage.carousel_images %}
               <div id="carousel-slide-{{ loop.index }}" class="carousel__slide{{ ' active' if loop.first }}" role="group" aria-roledescription="slide" aria-label="Slide {{ loop.index }} of {{ homepage.carousel_images | length }}">
-                <img class="carousel__image leave-alone" src="{%- imgPath img.src | safe,  'f_auto,q_auto:good,c_fill,w_1000,h_800' -%}" alt="{{ img.alt }}" loading="{{ 'eager' if loop.first else 'lazy' }}">
+                <img class="carousel__image leave-alone" src="{%- imgPath img.src | safe,  'f_auto,q_auto:good,c_limit,w_1000,h_800' -%}" alt="{{ img.alt }}" loading="{{ 'eager' if loop.first else 'lazy' }}">
               </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
## Summary
- Changes Cloudinary crop mode from `c_fill` to `c_limit` for homepage carousel images
- Prevents images from being cropped, which was cutting off parts of photos (e.g., people in group shots)
- Images will now scale to fit within max dimensions while preserving the entire image

## Test plan
- [x] View homepage carousel and verify images display fully without cropping
- [x] Check that the group photo (`alldeptphoto2022.jpg`) shows all people
