### PR TITLE
docs: simplify KnoxBox page and add call-to-action

### DIFF
--- a/src/pages/services/knoxbox.mdx
+++ b/src/pages/services/knoxbox.mdx
@@ -6,18 +6,18 @@ nav_title: "KnoxBox"
 
 <StyledImage src="/assets/media/knoxbox.png" alt="Residential KnoxBox" size="medium" align="center" />
 
-Locked doors and secured entry points can delay emergency response. Enable first responders rapid access by installing a secure UL listed KnoxBox.
+Locked doors can delay emergency response. A [KnoxBox](https://www.knoxbox.com) is a high-security, UL-listed key safe that allows first responders to quickly enter your home, business, or gate without forced entry.
 
-[KnoxBox](https://www.knoxbox.com) products are high-security key safes which allow first responders to quickly enter a home, business, or gate without forced entry. They are built to resist physical attack, vandalism, and extreme weather conditions.
+Each KnoxBox is keyed specifically for San Juan Island Fire & Rescue—only we have access.
 
-[KnoxBox](https://www.knoxbox.com) products must be ordered online and are specifically keyed so that only San Juan Island Fire & Rescue has access. Read their [How to Buy Knox Products](https://www.knoxbox.com/Support/Instructions) help guide to learn more.
+## How to Order
 
-To place an order you will need to:
-1. Go to the [Knockbox product page](https://www.knoxbox.com/Products)
-1. You'll be asked to select your location and department.  Select **Washington State** and enter **San Juan Co** and select **San Juan Co Fire Dist #3**
-1. If you are looking for a simple residential box which will only hold one key, select the entry labelled as "Residential Use ONLY - HomeBoxes". Otherwise select the other entry.
-1. Once you've ordered your system, SJIF&R will automatically be notified that you've placed an order.  We'll contact you if we have any questions.
-1. When you receive the KnoxBox it will be unlocked, allowing you to mount it in the desired location. Once it has been mounted, please call us at (360) 378-5334 so we can arrange a visit to finalize your KnoxBox setup.
+1. Visit the [KnoxBox Products](https://www.knoxbox.com/Products) page
+2. Select **Washington State**, enter **San Juan Co**, then choose **San Juan Co Fire Dist #3**
+3. Choose your product: select "Residential Use ONLY - HomeBoxes" for a single-key home box, or the other option for businesses and multi-key needs
+4. Complete your order—we'll be notified automatically and will contact you if needed
+5. When your KnoxBox arrives, mount it and call us at **(360) 378-5334** to schedule a visit to finalize setup
 
+<a href="https://www.knoxbox.com/Products" class="btn btn-primary">Order Your KnoxBox</a>
 
-**Note:** SJIF&R receives no money from KnoxBox.
+*SJIF&R receives no money from KnoxBox sales.*


### PR DESCRIPTION
## Summary
- Streamlines intro from 3 paragraphs to 2 concise ones
- Adds "How to Order" section header for clarity
- Simplifies the 5-step ordering process
- Fixes typo (Knockbox → KnoxBox)
- Adds prominent "Order Your KnoxBox" call-to-action button
- Makes phone number bold for visibility

## Test plan
- [x] View /services/knoxbox/ page and verify content displays correctly
- [x] Verify the "Order Your KnoxBox" button links to KnoxBox products page
- [x] Check that the page renders properly on mobile
