### PR TITLE
Move quick links before widgets on mobile

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -974,6 +974,19 @@ body {
   grid-area: subsidebar;
 }
 
+.l-grid__quicklinks {
+  grid-area: quicklinks;
+}
+
+/* Homepage layout: quicklinks before widgets on mobile */
+.l-grid--home {
+  grid-template-areas:
+    "quicklinks quicklinks"
+    "sidebar sidebar"
+    "main main"
+    "subsidebar subsidebar";
+}
+
 .l-grid--media {
   display: grid;
   gap: 1rem 0;
@@ -993,6 +1006,13 @@ body {
       "main subsidebar";
     grid-template-columns: 2.5fr minmax(240px, 1fr);
     gap: 60px;
+  }
+
+  .l-grid--home {
+    grid-template-areas:
+      "quicklinks sidebar"
+      "main sidebar"
+      "main subsidebar";
   }
 
   .l-grid--auto {

--- a/src/pages/homepage.njk
+++ b/src/pages/homepage.njk
@@ -10,27 +10,27 @@ header_image_source:
 {% extends 'base.njk' %}
 
 {% block content %}
-  <div class="l-grid l-grid--2col flipped">
+  <div class="l-grid l-grid--2col l-grid--home">
+    <section class="l-grid__quicklinks quick-actions-box">
+      <header class="quick-actions-box__header">
+        <h2>Quick Links</h2>
+      </header>
+      <nav class="quick-actions-box__body" aria-label="Quick links">
+        <a href="/services/burn-permits/" class="btn btn-primary">
+          <svg><use xlink:href="#flame"></use></svg>
+          Burn Permits
+        </a>
+        <a href="/about/fire-insurance/" class="btn btn-primary">
+          <svg><use xlink:href="#fact-check"></use></svg>
+          Fire Insurance Info
+        </a>
+        <a href="/about/governance/" class="btn btn-primary">
+          <svg><use xlink:href="#stats"></use></svg>
+          Governance
+        </a>
+      </nav>
+    </section>
     <div class="l-grid__main block-content">
-      <section class="quick-actions-box">
-        <header class="quick-actions-box__header">
-          <h2>Quick Links</h2>
-        </header>
-        <nav class="quick-actions-box__body" aria-label="Quick links">
-          <a href="/services/burn-permits/" class="btn btn-primary">
-            <svg><use xlink:href="#flame"></use></svg>
-            Burn Permits
-          </a>
-          <a href="/about/fire-insurance/" class="btn btn-primary">
-            <svg><use xlink:href="#fact-check"></use></svg>
-            Fire Insurance Info
-          </a>
-          <a href="/about/governance/" class="btn btn-primary">
-            <svg><use xlink:href="#stats"></use></svg>
-            Governance
-          </a>
-        </nav>
-      </section>
       <ul class="l-grid l-grid--auto">
         {% for post in posts | reverse | limit(homepage.number_news_stories) %}
           <li class="card">


### PR DESCRIPTION
On mobile devices, quick links now appear before the sidebar widgets (burn status and call stats) for better user experience. Desktop layout remains unchanged with quick links at the top of the main column.