### PR TITLE
chore: remove unused environment variables

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -82,9 +82,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
-          AAD_CLIENT_ID: ${{ secrets.AAD_CLIENT_ID }}
-          AAD_CLIENT_SECRET: ${{ secrets.AAD_CLIENT_SECRET }}
-          ALLOWED_EDITOR_GROUPS: ${{ secrets.ALLOWED_EDITOR_GROUPS }}
           COSMOS_DB_CONNECTION_STRING: ${{ secrets.COSMOS_DB_CONNECTION_STRING }}
           COSMOS_DB_NAME: ${{ secrets.COSMOS_DB_NAME }}
           TINA_PUBLIC_IS_LOCAL: "false"
@@ -110,9 +107,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
-          AAD_CLIENT_ID: ${{ secrets.AAD_CLIENT_ID }}
-          AAD_CLIENT_SECRET: ${{ secrets.AAD_CLIENT_SECRET }}
-          ALLOWED_EDITOR_GROUPS: ${{ secrets.ALLOWED_EDITOR_GROUPS }}
           COSMOS_DB_CONNECTION_STRING: ${{ secrets.COSMOS_DB_CONNECTION_STRING }}
           COSMOS_DB_NAME: ${{ secrets.COSMOS_DB_NAME }}
           TINA_PUBLIC_IS_LOCAL: "false"


### PR DESCRIPTION
## Summary
Remove unused environment variables from the deployment workflow.

**Removed:**
- `AAD_CLIENT_ID` - Auth now configured via Azure portal (Simple mode)
- `AAD_CLIENT_SECRET` - Auth now configured via Azure portal (Simple mode)
- `ALLOWED_EDITOR_GROUPS` - Was for custom role checking (no longer used)

**Still used (kept):**
- `COSMOS_DB_CONNECTION_STRING` - TinaCMS database
- `COSMOS_DB_NAME` - TinaCMS database
- `GITHUB_*` - TinaCMS GitHub integration
- `TINA_PUBLIC_IS_LOCAL` - Used by TinaCMS to detect local vs production

## Azure Portal Cleanup
After merging, these can also be removed from the SWA environment variables in Azure Portal:
- `AAD_CLIENT_ID`
- `AAD_CLIENT_SECRET`
- `AZURE_CLIENT_ID`
- `AZURE_CLIENT_SECRET_APP_SETTING_NAME`
- `TINA_PUBLIC_IS_LOCAL` (set in workflow, not needed as app setting)

🤖 Generated with [Claude Code](https://claude.ai/code)