### PR TITLE
Cancel previous deploys on new commits

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -14,6 +14,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_deploy_job:
     # For workflow_run (main): only if CI succeeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
When multiple commits trigger workflows, this ensures older runs are automatically cancelled, saving CI resources and avoiding redundant deployments from stale commits.