### PR TITLE
Add gallery link to home carousel

### DIFF
--- a/src/pages/homepage.liquid
+++ b/src/pages/homepage.liquid
@@ -101,6 +101,11 @@ scripts: '<script src="/js/carousel.js" defer></script>'
       </div>
       {% endif %}
     </section>
+    <div style="margin-top:1rem" class="text-center">
+      <a class="btn btn-secondary" href="/about/gallery/">
+        View Gallery »
+      </a>
+    </div>
   </div>
 
   <aside class="l-grid__sidebar">


### PR DESCRIPTION
Add a "View Gallery" button linking to /about/gallery/ below the carousel section, matching the style of the "News Archive" link.