### PR TITLE
Fix Facebook widget not displaying on iPhone

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -23,7 +23,7 @@
     }
   },
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://res.cloudinary.com https://*.cloudinary.com; font-src 'self' data:; connect-src 'self' https://res.cloudinary.com https://api.cloudinary.com https://content.cloudinary.com; frame-src 'self' https://www.facebook.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://res.cloudinary.com https://*.cloudinary.com; font-src 'self' data:; connect-src 'self' https://res.cloudinary.com https://api.cloudinary.com https://content.cloudinary.com; frame-src 'self' https://*.facebook.com https://*.facebook.net; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
     "X-XSS-Protection": "1; mode=block",


### PR DESCRIPTION
The Facebook Page Plugin wasn't displaying on iPhone because the Content-Security-Policy only allowed www.facebook.com. Facebook uses additional domains on mobile devices:
- web.facebook.com - for mobile and international users
- staticxx.facebook.com - for static resources in iframes