### PR TITLE
Add face detection to gallery thumbnails

### DIFF
--- a/src/pages/about/gallery.liquid
+++ b/src/pages/about/gallery.liquid
@@ -13,7 +13,7 @@ scripts: '<script src="/js/gallery.js" defer></script>'
       <button type="button" class="photo-gallery__item" data-index="{{ forloop.index0 }}">
         <img
           class="photo-gallery__thumb leave-alone"
-          src="{% imgPath img.src, 'f_auto,q_auto:good,c_fill,w_300,h_200' %}"
+          src="{% imgPath img.src, 'f_auto,q_auto:good,c_fill,g_auto:faces,w_300,h_200' %}"
           alt="{{ img.alt }}"
           loading="lazy"
         >


### PR DESCRIPTION
## Summary
- Use Cloudinary `g_auto:faces` to automatically focus on faces when cropping gallery thumbnails
- Falls back to content-aware cropping if no faces detected

## Test plan
- [x] View gallery page and verify thumbnails with people focus on faces
- [x] Verify thumbnails without people still crop appropriately
