### PR TITLE
Add user info to TinaCMS git commits

### DIFF
--- a/api/src/functions/media.js
+++ b/api/src/functions/media.js
@@ -5,7 +5,7 @@ const {
   deleteMedia,
   getCorsHeaders,
 } = require("../lib/media.js");
-const { requireAdmin, getUserForLogging } = require("../lib/auth.js");
+const { requireAdmin, getUserForLogging, getGitAuthor } = require("../lib/auth.js");
 
 app.http("media", {
   methods: ["GET", "POST", "DELETE", "OPTIONS"],
@@ -24,6 +24,7 @@ app.http("media", {
       return { ...authError, headers: corsHeaders };
     }
 
+    const author = getGitAuthor(request);
     context.log(`Media API access by user: ${getUserForLogging(request)}`);
 
     try {
@@ -44,7 +45,7 @@ app.http("media", {
 
         const arrayBuffer = await file.arrayBuffer();
         const base64Content = Buffer.from(arrayBuffer).toString("base64");
-        const result = await uploadMedia(file.name, base64Content, directory);
+        const result = await uploadMedia(file.name, base64Content, directory, author);
         return { status: 200, headers: corsHeaders, jsonBody: result };
       }
 
@@ -56,7 +57,7 @@ app.http("media", {
           return { status: 400, headers: corsHeaders, jsonBody: { error: "No filepath provided" } };
         }
 
-        await deleteMedia(filepath);
+        await deleteMedia(filepath, author);
         return { status: 200, headers: corsHeaders, jsonBody: { success: true } };
       }
 

--- a/api/src/functions/tina.js
+++ b/api/src/functions/tina.js
@@ -1,6 +1,7 @@
 const { app } = require("@azure/functions");
 const { TinaNodeBackend, LocalBackendAuthProvider } = require("@tinacms/datalayer");
-const { requireAdmin, getUserForLogging } = require("../lib/auth.js");
+const { requireAdmin, getUserForLogging, getGitAuthor } = require("../lib/auth.js");
+const { runWithAuthor } = require("../lib/git-provider.js");
 
 const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === "true";
 
@@ -42,52 +43,56 @@ app.http("tina", {
       return authError;
     }
 
+    const author = getGitAuthor(request);
     context.log(`TinaCMS access by user: ${getUserForLogging(request)}`);
 
-    try {
-      const tinaBackend = await getBackend();
+    // Wrap the request in author context so git commits include user attribution
+    return runWithAuthor(author, async () => {
+      try {
+        const tinaBackend = await getBackend();
 
-      // Convert Azure Functions request to Node-like request
-      const body = await request.text();
-      const nodeReq = {
-        method: request.method,
-        url: `/api/tina/${path}`,
-        headers: Object.fromEntries(request.headers.entries()),
-        body: body ? JSON.parse(body) : undefined,
-        query: Object.fromEntries(new URL(request.url).searchParams.entries()),
-      };
+        // Convert Azure Functions request to Node-like request
+        const body = await request.text();
+        const nodeReq = {
+          method: request.method,
+          url: `/api/tina/${path}`,
+          headers: Object.fromEntries(request.headers.entries()),
+          body: body ? JSON.parse(body) : undefined,
+          query: Object.fromEntries(new URL(request.url).searchParams.entries()),
+        };
 
-      // Create response collector
-      let statusCode = 200;
-      const headers = {};
-      const chunks = [];
+        // Create response collector
+        let statusCode = 200;
+        const headers = {};
+        const chunks = [];
 
-      const nodeRes = {
-        statusCode: 200,
-        setHeader: (name, value) => { headers[name.toLowerCase()] = value; },
-        getHeader: (name) => headers[name.toLowerCase()],
-        writeHead: (code, hdrs) => {
-          statusCode = code;
-          if (hdrs) Object.entries(hdrs).forEach(([k, v]) => { headers[k.toLowerCase()] = v; });
-        },
-        write: (chunk) => { chunks.push(chunk); return true; },
-        end: (chunk) => { if (chunk) chunks.push(chunk); },
-      };
+        const nodeRes = {
+          statusCode: 200,
+          setHeader: (name, value) => { headers[name.toLowerCase()] = value; },
+          getHeader: (name) => headers[name.toLowerCase()],
+          writeHead: (code, hdrs) => {
+            statusCode = code;
+            if (hdrs) Object.entries(hdrs).forEach(([k, v]) => { headers[k.toLowerCase()] = v; });
+          },
+          write: (chunk) => { chunks.push(chunk); return true; },
+          end: (chunk) => { if (chunk) chunks.push(chunk); },
+        };
 
-      await tinaBackend(nodeReq, nodeRes);
+        await tinaBackend(nodeReq, nodeRes);
 
-      const responseBody = chunks.join("");
-      return {
-        status: statusCode,
-        headers,
-        body: responseBody,
-      };
-    } catch (error) {
-      context.error("TinaCMS error:", error.message, error.stack);
-      return {
-        status: 500,
-        jsonBody: { error: "Internal server error" },
-      };
-    }
+        const responseBody = chunks.join("");
+        return {
+          status: statusCode,
+          headers,
+          body: responseBody,
+        };
+      } catch (error) {
+        context.error("TinaCMS error:", error.message, error.stack);
+        return {
+          status: 500,
+          jsonBody: { error: "Internal server error" },
+        };
+      }
+    });
   },
 });

--- a/api/src/lib/auth.js
+++ b/api/src/lib/auth.js
@@ -96,9 +96,35 @@ function getUserForLogging(request) {
   return principal.userDetails || principal.userId || "unknown";
 }
 
+/**
+ * Get Git author info from the authenticated user for commit attribution
+ * @param {Request} request - Azure Functions request object
+ * @returns {{name: string, email: string} | null} Author info for Git commits, or null if not authenticated
+ */
+function getGitAuthor(request) {
+  const principal = getClientPrincipal(request);
+  if (!principal) {
+    return null;
+  }
+
+  // userDetails is typically the email address from Azure AD
+  const email = principal.userDetails;
+  // Try to extract a display name from claims, or fall back to email prefix
+  const name = principal.claims?.find(c => c.typ === "name")?.val
+    || (email ? email.split("@")[0] : null)
+    || principal.userId
+    || "Unknown User";
+
+  return {
+    name,
+    email: email || `${principal.userId}@users.noreply.github.com`,
+  };
+}
+
 module.exports = {
   getClientPrincipal,
   hasAdminRole,
   requireAdmin,
   getUserForLogging,
+  getGitAuthor,
 };

--- a/api/src/lib/git-provider.js
+++ b/api/src/lib/git-provider.js
@@ -1,0 +1,161 @@
+/**
+ * Custom GitHub Git Provider with commit author attribution
+ *
+ * This extends the standard tinacms-gitprovider-github to add author/committer
+ * information to commits based on the authenticated user making the change.
+ *
+ * Uses AsyncLocalStorage to pass user context through the TinaCMS data layer
+ * without modifying the GitHubProvider interface.
+ */
+
+const { AsyncLocalStorage } = require("node:async_hooks");
+const { Octokit } = require("@octokit/rest");
+
+// AsyncLocalStorage instance for request-scoped author context
+const authorContext = new AsyncLocalStorage();
+
+/**
+ * Run a function with author context available
+ * @param {{name: string, email: string}} author - Git author info
+ * @param {Function} fn - Function to run with context
+ * @returns {Promise<any>} Result of fn
+ */
+function runWithAuthor(author, fn) {
+  return authorContext.run(author, fn);
+}
+
+/**
+ * Get the current author context (if any)
+ * @returns {{name: string, email: string} | undefined}
+ */
+function getAuthorContext() {
+  return authorContext.getStore();
+}
+
+/**
+ * Custom GitHub provider that adds author info to commits
+ */
+class AuthoredGitHubProvider {
+  constructor(options) {
+    this.owner = options.owner;
+    this.repo = options.repo;
+    this.branch = options.branch;
+    this.token = options.token;
+    this.commitMessage = options.commitMessage || "Edited with TinaCMS";
+    this.rootPath = options.rootPath || "";
+
+    this.octokit = new Octokit({
+      auth: this.token,
+      ...options.octokitOptions,
+    });
+  }
+
+  /**
+   * Get the full path for a file (with optional root path prefix)
+   */
+  getFilePath(key) {
+    if (this.rootPath) {
+      return `${this.rootPath}/${key}`.replace(/\/+/g, "/");
+    }
+    return key;
+  }
+
+  /**
+   * Build commit author info, including the authenticated user if available
+   */
+  getCommitInfo() {
+    const author = getAuthorContext();
+
+    // Build commit message with author attribution
+    let message = this.commitMessage;
+    if (author?.email) {
+      message = `${this.commitMessage} by ${author.email}`;
+    }
+
+    const result = { message };
+
+    // Add author/committer to the commit if we have user context
+    if (author) {
+      result.author = {
+        name: author.name,
+        email: author.email,
+      };
+      result.committer = {
+        name: author.name,
+        email: author.email,
+      };
+    }
+
+    return result;
+  }
+
+  /**
+   * Create or update a file
+   */
+  async onPut(key, value) {
+    const path = this.getFilePath(key);
+    const commitInfo = this.getCommitInfo();
+
+    // Check if file exists to get SHA for update
+    let sha;
+    try {
+      const { data } = await this.octokit.repos.getContent({
+        owner: this.owner,
+        repo: this.repo,
+        path,
+        ref: this.branch,
+      });
+      sha = data.sha;
+    } catch (e) {
+      // File doesn't exist, that's fine for create
+      if (e.status !== 404) {
+        throw e;
+      }
+    }
+
+    await this.octokit.repos.createOrUpdateFileContents({
+      owner: this.owner,
+      repo: this.repo,
+      path,
+      message: commitInfo.message,
+      content: Buffer.from(value).toString("base64"),
+      branch: this.branch,
+      sha,
+      author: commitInfo.author,
+      committer: commitInfo.committer,
+    });
+  }
+
+  /**
+   * Delete a file
+   */
+  async onDelete(key) {
+    const path = this.getFilePath(key);
+    const commitInfo = this.getCommitInfo();
+
+    // Get file SHA (required for delete)
+    const { data } = await this.octokit.repos.getContent({
+      owner: this.owner,
+      repo: this.repo,
+      path,
+      ref: this.branch,
+    });
+
+    await this.octokit.repos.deleteFile({
+      owner: this.owner,
+      repo: this.repo,
+      path,
+      message: commitInfo.message,
+      sha: data.sha,
+      branch: this.branch,
+      author: commitInfo.author,
+      committer: commitInfo.committer,
+    });
+  }
+}
+
+module.exports = {
+  AuthoredGitHubProvider,
+  runWithAuthor,
+  getAuthorContext,
+};

--- a/api/src/lib/media.js
+++ b/api/src/lib/media.js
@@ -194,7 +194,8 @@ function createMediaOperations(deps = {}) {
   }
 
   // Upload a file to the media directory
-  async function uploadMedia(filename, content, directory = "") {
+  // author: optional { name, email } for commit attribution
+  async function uploadMedia(filename, content, directory = "", author = null) {
     // Validate inputs are safe
     if (!isPathSafe(directory) || !isPathSafe(filename)) {
       throw new Error("Invalid path");
@@ -226,15 +227,24 @@ function createMediaOperations(deps = {}) {
       // File doesn't exist, that's fine
     }
 
-    const commitMessage = sha
+    // Build commit message with author attribution
+    let commitMessage = sha
       ? `Update media: ${filename}`
       : `Add media: ${filename}${optimized ? " (optimized)" : ""}`;
+    if (author?.email) {
+      commitMessage += ` by ${author.email}`;
+    }
 
     const body = {
       message: commitMessage,
       content: finalContent,
       branch,
       ...(sha && { sha }),
+      // Include author/committer for audit trail
+      ...(author && {
+        author: { name: author.name, email: author.email },
+        committer: { name: author.name, email: author.email },
+      }),
     };
 
     const result = await githubRequest(`/contents/${encodedPath}`, {
@@ -248,7 +258,8 @@ function createMediaOperations(deps = {}) {
   }
 
   // Delete a file from the media directory
-  async function deleteMedia(filepath) {
+  // author: optional { name, email } for commit attribution
+  async function deleteMedia(filepath, author = null) {
     // Validate filepath is safe and within media root
     if (!isPathSafe(filepath)) {
       throw new Error("Invalid file path");
@@ -262,12 +273,23 @@ function createMediaOperations(deps = {}) {
     const encodedPath = encodePathForGitHub(filepath);
     const existing = await githubRequest(`/contents/${encodedPath}?ref=${branch}`);
 
+    // Build commit message with author attribution
+    let commitMessage = `Delete media: ${filepath.split("/").pop()}`;
+    if (author?.email) {
+      commitMessage += ` by ${author.email}`;
+    }
+
     await githubRequest(`/contents/${encodedPath}`, {
       method: "DELETE",
       body: JSON.stringify({
-        message: `Delete media: ${filepath.split("/").pop()}`,
+        message: commitMessage,
         sha: existing.sha,
         branch,
+        // Include author/committer for audit trail
+        ...(author && {
+          author: { name: author.name, email: author.email },
+          committer: { name: author.name, email: author.email },
+        }),
       }),
     });
 

--- a/api/tina/database.js
+++ b/api/tina/database.js
@@ -1,6 +1,6 @@
 const { createDatabase, createLocalDatabase, resolve: tinaResolve } = require("@tinacms/datalayer");
 const { MongodbLevel } = require("mongodb-level");
-const { GitHubProvider } = require("tinacms-gitprovider-github");
+const { AuthoredGitHubProvider } = require("../src/lib/git-provider.js");
 const { getGitHubToken, getGitHubConfig } = require("../src/lib/github.js");
 
 const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === "true";
@@ -22,7 +22,7 @@ async function createProdDatabase() {
   console.log("  GitHub token generated successfully");
 
   return createDatabase({
-    gitProvider: new GitHubProvider({
+    gitProvider: new AuthoredGitHubProvider({
       branch,
       owner,
       repo,

--- a/tests/api-auth.test.js
+++ b/tests/api-auth.test.js
@@ -6,6 +6,7 @@ const {
   hasAdminRole,
   requireAdmin,
   getUserForLogging,
+  getGitAuthor,
 } = require("../api/src/lib/auth.js");
 
 // Helper to create a mock request with headers
@@ -294,6 +295,121 @@ describe("auth module", () => {
       });
 
       assert.strictEqual(getUserForLogging(request), "preferred@example.com");
+    });
+  });
+
+  describe("getGitAuthor", () => {
+    it("returns null when no client principal", () => {
+      const request = createMockRequest({});
+      assert.strictEqual(getGitAuthor(request), null);
+    });
+
+    it("returns author object with email from userDetails", () => {
+      const principal = {
+        userId: "user123",
+        userDetails: "jane.doe@sjifire.org",
+        userRoles: ["admin"],
+      };
+      const request = createMockRequest({
+        "x-ms-client-principal": encodeClientPrincipal(principal),
+      });
+
+      const author = getGitAuthor(request);
+      assert.strictEqual(author.email, "jane.doe@sjifire.org");
+    });
+
+    it("extracts name from email prefix when no name claim", () => {
+      const principal = {
+        userId: "user123",
+        userDetails: "jane.doe@sjifire.org",
+        userRoles: ["admin"],
+      };
+      const request = createMockRequest({
+        "x-ms-client-principal": encodeClientPrincipal(principal),
+      });
+
+      const author = getGitAuthor(request);
+      assert.strictEqual(author.name, "jane.doe");
+    });
+
+    it("uses name claim when available", () => {
+      const principal = {
+        userId: "user123",
+        userDetails: "jane.doe@sjifire.org",
+        userRoles: ["admin"],
+        claims: [
+          { typ: "name", val: "Jane Doe" },
+          { typ: "oid", val: "some-guid" },
+        ],
+      };
+      const request = createMockRequest({
+        "x-ms-client-principal": encodeClientPrincipal(principal),
+      });
+
+      const author = getGitAuthor(request);
+      assert.strictEqual(author.name, "Jane Doe");
+      assert.strictEqual(author.email, "jane.doe@sjifire.org");
+    });
+
+    it("falls back to userId for name when no email", () => {
+      const principal = {
+        userId: "user-guid-123",
+        userRoles: ["admin"],
+      };
+      const request = createMockRequest({
+        "x-ms-client-principal": encodeClientPrincipal(principal),
+      });
+
+      const author = getGitAuthor(request);
+      assert.strictEqual(author.name, "user-guid-123");
+    });
+
+    it("generates noreply email when userDetails is missing", () => {
+      const principal = {
+        userId: "user-guid-123",
+        userRoles: ["admin"],
+      };
+      const request = createMockRequest({
+        "x-ms-client-principal": encodeClientPrincipal(principal),
+      });
+
+      const author = getGitAuthor(request);
+      assert.strictEqual(author.email, "user-guid-123@users.noreply.github.com");
+    });
+
+    it("returns 'Unknown User' for name when no identifiable info", () => {
+      const principal = {
+        userRoles: ["admin"],
+      };
+      const request = createMockRequest({
+        "x-ms-client-principal": encodeClientPrincipal(principal),
+      });
+
+      const author = getGitAuthor(request);
+      assert.strictEqual(author.name, "Unknown User");
+    });
+
+    it("handles empty claims array", () => {
+      const principal = {
+        userId: "user123",
+        userDetails: "test@example.com",
+        userRoles: ["admin"],
+        claims: [],
+      };
+      const request = createMockRequest({
+        "x-ms-client-principal": encodeClientPrincipal(principal),
+      });
+
+      const author = getGitAuthor(request);
+      assert.strictEqual(author.name, "test");
+      assert.strictEqual(author.email, "test@example.com");
+    });
+
+    it("returns null for invalid principal", () => {
+      const request = createMockRequest({
+        "x-ms-client-principal": "invalid-base64!!!",
+      });
+      assert.strictEqual(getGitAuthor(request), null);
     });
   });
 });

--- a/tests/api-git-provider.test.js
+++ b/tests/api-git-provider.test.js
@@ -1,0 +1,251 @@
+const { describe, it, beforeEach } = require("node:test");
+const assert = require("node:assert");
+
+const {
+  AuthoredGitHubProvider,
+  runWithAuthor,
+  getAuthorContext,
+} = require("../api/src/lib/git-provider.js");
+
+describe("git-provider module", () => {
+  describe("runWithAuthor / getAuthorContext", () => {
+    it("makes author context available within callback", async () => {
+      const author = { name: "Jane Doe", email: "jane@example.com" };
+      let capturedContext = null;
+
+      await runWithAuthor(author, async () => {
+        capturedContext = getAuthorContext();
+      });
+
+      assert.deepStrictEqual(capturedContext, author);
+    });
+
+    it("returns undefined outside of runWithAuthor context", () => {
+      const context = getAuthorContext();
+      assert.strictEqual(context, undefined);
+    });
+
+    it("isolates context between concurrent calls", async () => {
+      const author1 = { name: "User One", email: "one@example.com" };
+      const author2 = { name: "User Two", email: "two@example.com" };
+      const results = [];
+
+      await Promise.all([
+        runWithAuthor(author1, async () => {
+          // Small delay to interleave execution
+          await new Promise((r) => setTimeout(r, 10));
+          results.push({ expected: author1, actual: getAuthorContext() });
+        }),
+        runWithAuthor(author2, async () => {
+          await new Promise((r) => setTimeout(r, 5));
+          results.push({ expected: author2, actual: getAuthorContext() });
+        }),
+      ]);
+
+      for (const { expected, actual } of results) {
+        assert.deepStrictEqual(actual, expected);
+      }
+    });
+
+    it("handles null author context", async () => {
+      let capturedContext = "not-set";
+
+      await runWithAuthor(null, async () => {
+        capturedContext = getAuthorContext();
+      });
+
+      assert.strictEqual(capturedContext, null);
+    });
+
+    it("returns callback result", async () => {
+      const result = await runWithAuthor({ name: "Test", email: "test@test.com" }, async () => {
+        return { success: true, data: "test" };
+      });
+
+      assert.deepStrictEqual(result, { success: true, data: "test" });
+    });
+
+    it("propagates errors from callback", async () => {
+      await assert.rejects(
+        runWithAuthor({ name: "Test", email: "test@test.com" }, async () => {
+          throw new Error("Test error");
+        }),
+        /Test error/
+      );
+    });
+  });
+
+  describe("AuthoredGitHubProvider", () => {
+    describe("constructor", () => {
+      it("stores configuration options", () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+        });
+
+        assert.strictEqual(provider.owner, "test-owner");
+        assert.strictEqual(provider.repo, "test-repo");
+        assert.strictEqual(provider.branch, "main");
+      });
+
+      it("uses default commit message when not provided", () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+        });
+
+        assert.strictEqual(provider.commitMessage, "Edited with TinaCMS");
+      });
+
+      it("accepts custom commit message", () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+          commitMessage: "Custom commit message",
+        });
+
+        assert.strictEqual(provider.commitMessage, "Custom commit message");
+      });
+
+      it("accepts optional rootPath", () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+          rootPath: "content",
+        });
+
+        assert.strictEqual(provider.rootPath, "content");
+      });
+
+      it("defaults rootPath to empty string", () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+        });
+
+        assert.strictEqual(provider.rootPath, "");
+      });
+    });
+
+    describe("getFilePath", () => {
+      it("returns key as-is when no rootPath", () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+        });
+
+        assert.strictEqual(provider.getFilePath("path/to/file.json"), "path/to/file.json");
+      });
+
+      it("prepends rootPath when set", () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+          rootPath: "content",
+        });
+
+        assert.strictEqual(provider.getFilePath("posts/hello.json"), "content/posts/hello.json");
+      });
+
+      it("normalizes multiple slashes", () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+          rootPath: "content/",
+        });
+
+        assert.strictEqual(provider.getFilePath("/posts/hello.json"), "content/posts/hello.json");
+      });
+    });
+
+    describe("getCommitInfo", () => {
+      it("returns message without author when no context", () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+        });
+
+        const info = provider.getCommitInfo();
+
+        assert.strictEqual(info.message, "Edited with TinaCMS");
+        assert.strictEqual(info.author, undefined);
+        assert.strictEqual(info.committer, undefined);
+      });
+
+      it("includes author info when context is set", async () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+        });
+
+        const author = { name: "Jane Doe", email: "jane@sjifire.org" };
+
+        await runWithAuthor(author, async () => {
+          const info = provider.getCommitInfo();
+
+          assert.strictEqual(info.message, "Edited with TinaCMS by jane@sjifire.org");
+          assert.deepStrictEqual(info.author, { name: "Jane Doe", email: "jane@sjifire.org" });
+          assert.deepStrictEqual(info.committer, { name: "Jane Doe", email: "jane@sjifire.org" });
+        });
+      });
+
+      it("appends email to custom commit message", async () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+          commitMessage: "Content updated",
+        });
+
+        const author = { name: "John Smith", email: "john@example.com" };
+
+        await runWithAuthor(author, async () => {
+          const info = provider.getCommitInfo();
+
+          assert.strictEqual(info.message, "Content updated by john@example.com");
+        });
+      });
+
+      it("handles author with name but no email gracefully", async () => {
+        const provider = new AuthoredGitHubProvider({
+          owner: "test-owner",
+          repo: "test-repo",
+          branch: "main",
+          token: "test-token",
+        });
+
+        const author = { name: "Anonymous User", email: "" };
+
+        await runWithAuthor(author, async () => {
+          const info = provider.getCommitInfo();
+
+          // No email appended when email is empty
+          assert.strictEqual(info.message, "Edited with TinaCMS");
+          // Author info still included
+          assert.deepStrictEqual(info.author, { name: "Anonymous User", email: "" });
+        });
+      });
+    });
+  });
+});

--- a/tests/api-git-provider.test.js
+++ b/tests/api-git-provider.test.js
@@ -1,4 +1,4 @@
-const { describe, it, beforeEach } = require("node:test");
+const { describe, it } = require("node:test");
 const assert = require("node:assert");
 
 const {

--- a/tests/api-media.test.js
+++ b/tests/api-media.test.js
@@ -567,6 +567,96 @@ describe("media module", () => {
       // Filename should be URL-encoded
       assert.ok(putCall.endpoint.includes("my%20photo.jpg"), "Filename with space should be URL-encoded");
     });
+
+    it("includes author info in commit when provided", async () => {
+      const calls = [];
+      const mockGithubRequest = async (endpoint, options) => {
+        calls.push({ endpoint, options });
+        if (!options?.method) {
+          throw new Error("404");
+        }
+        return {
+          content: {
+            path: "src/assets/media/photo.jpg",
+            name: "photo.jpg",
+          },
+        };
+      };
+
+      const mediaOps = createMediaOperations({
+        getGitHubConfig: mockGetGitHubConfig,
+        githubRequest: mockGithubRequest,
+      });
+
+      const author = { name: "Jane Doe", email: "jane@sjifire.org" };
+      await mediaOps.uploadMedia("photo.jpg", "content", "", author);
+
+      const putCall = calls.find((c) => c.options?.method === "PUT");
+      const body = JSON.parse(putCall.options.body);
+
+      assert.strictEqual(body.message, "Add media: photo.jpg by jane@sjifire.org");
+      assert.deepStrictEqual(body.author, { name: "Jane Doe", email: "jane@sjifire.org" });
+      assert.deepStrictEqual(body.committer, { name: "Jane Doe", email: "jane@sjifire.org" });
+    });
+
+    it("omits author fields when author is null", async () => {
+      const calls = [];
+      const mockGithubRequest = async (endpoint, options) => {
+        calls.push({ endpoint, options });
+        if (!options?.method) {
+          throw new Error("404");
+        }
+        return {
+          content: {
+            path: "src/assets/media/photo.jpg",
+            name: "photo.jpg",
+          },
+        };
+      };
+
+      const mediaOps = createMediaOperations({
+        getGitHubConfig: mockGetGitHubConfig,
+        githubRequest: mockGithubRequest,
+      });
+
+      await mediaOps.uploadMedia("photo.jpg", "content", "", null);
+
+      const putCall = calls.find((c) => c.options?.method === "PUT");
+      const body = JSON.parse(putCall.options.body);
+
+      assert.strictEqual(body.message, "Add media: photo.jpg");
+      assert.strictEqual(body.author, undefined);
+      assert.strictEqual(body.committer, undefined);
+    });
+
+    it("includes author in update commit message", async () => {
+      const calls = [];
+      const mockGithubRequest = async (endpoint, options) => {
+        calls.push({ endpoint, options });
+        if (!options?.method) {
+          return { sha: "existing-sha" };
+        }
+        return {
+          content: {
+            path: "src/assets/media/photo.jpg",
+            name: "photo.jpg",
+          },
+        };
+      };
+
+      const mediaOps = createMediaOperations({
+        getGitHubConfig: mockGetGitHubConfig,
+        githubRequest: mockGithubRequest,
+      });
+
+      const author = { name: "John Smith", email: "john@example.com" };
+      await mediaOps.uploadMedia("photo.jpg", "newcontent", "", author);
+
+      const putCall = calls.find((c) => c.options?.method === "PUT");
+      const body = JSON.parse(putCall.options.body);
+
+      assert.strictEqual(body.message, "Update media: photo.jpg by john@example.com");
+    });
   });
 
   describe("deleteMedia (with dependency injection)", () => {
@@ -626,6 +716,57 @@ describe("media module", () => {
       const deleteCall = calls.find((c) => c.options?.method === "DELETE");
       const body = JSON.parse(deleteCall.options.body);
       assert.strictEqual(body.message, "Delete media: file.jpg");
+    });
+
+    it("includes author info in delete commit when provided", async () => {
+      const calls = [];
+      const mockGithubRequest = async (endpoint, options) => {
+        calls.push({ endpoint, options });
+        if (!options?.method) {
+          return { sha: "file-sha" };
+        }
+        return {};
+      };
+
+      const mediaOps = createMediaOperations({
+        getGitHubConfig: mockGetGitHubConfig,
+        githubRequest: mockGithubRequest,
+      });
+
+      const author = { name: "Jane Doe", email: "jane@sjifire.org" };
+      await mediaOps.deleteMedia("src/assets/media/photo.jpg", author);
+
+      const deleteCall = calls.find((c) => c.options?.method === "DELETE");
+      const body = JSON.parse(deleteCall.options.body);
+
+      assert.strictEqual(body.message, "Delete media: photo.jpg by jane@sjifire.org");
+      assert.deepStrictEqual(body.author, { name: "Jane Doe", email: "jane@sjifire.org" });
+      assert.deepStrictEqual(body.committer, { name: "Jane Doe", email: "jane@sjifire.org" });
+    });
+
+    it("omits author fields when author is null for delete", async () => {
+      const calls = [];
+      const mockGithubRequest = async (endpoint, options) => {
+        calls.push({ endpoint, options });
+        if (!options?.method) {
+          return { sha: "file-sha" };
+        }
+        return {};
+      };
+
+      const mediaOps = createMediaOperations({
+        getGitHubConfig: mockGetGitHubConfig,
+        githubRequest: mockGithubRequest,
+      });
+
+      await mediaOps.deleteMedia("src/assets/media/photo.jpg", null);
+
+      const deleteCall = calls.find((c) => c.options?.method === "DELETE");
+      const body = JSON.parse(deleteCall.options.body);
+
+      assert.strictEqual(body.message, "Delete media: photo.jpg");
+      assert.strictEqual(body.author, undefined);
+      assert.strictEqual(body.committer, undefined);
     });
   });
 });


### PR DESCRIPTION
Track which user made content changes in the git history:

- Add getGitAuthor() helper to extract user info from Azure AD auth
- Create AuthoredGitHubProvider that includes author/committer in commits
- Use AsyncLocalStorage to pass user context through TinaCMS data layer
- Update media operations to include author attribution

Commits now include:
- Git author/committer fields with the user's name and email
- Commit message suffix showing who made the change (e.g. "by user@org.com")