### PR TITLE
Add Education & Preparedness Services sub-tab

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1161,6 +1161,36 @@ body {
   text-decoration: underline;
 }
 
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+  margin: 24px 0;
+}
+
+.card--link {
+  padding: 24px;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card--link:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 16px rgb(0, 0, 0, 0.2);
+}
+
+.card--link h3 {
+  color: var(--red);
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.card--link p {
+  margin: 0;
+  color: #333;
+}
+
 .widget {
   width: 100%;
   table-layout: fixed;

--- a/src/pages/services/burn-permits.mdx
+++ b/src/pages/services/burn-permits.mdx
@@ -1,6 +1,6 @@
 ---
 title: Burn Permits
-nav_order: 4
+nav_order: 5
 include_burn_widget: true
 sidebar: >
   <div class="sidebar-block">

--- a/src/pages/services/driveway-access.mdx
+++ b/src/pages/services/driveway-access.mdx
@@ -20,11 +20,10 @@ When seconds count, your driveway matters. Fire apparatus need adequate width, c
 
 ## Why Access Matters
 
-Our apparatus are large and heavy—our biggest engine weighs 54,000 pounds. A driveway that's too narrow, too steep, or blocked by vegetation can:
+Our apparatus are large and heavy—our biggest weighs 54,000 pounds. A driveway that's too narrow, too steep, or blocked by vegetation can:
 
 * Delay response while crews find alternate access
 * Force firefighters to lay hundreds of feet of hose by hand
-* Prevent ladder trucks from reaching upper floors
 * Put both residents and firefighters at risk
 
 ## Access Requirements
@@ -52,6 +51,3 @@ If you're building a new driveway or making changes:
 2. Contact Community Development at 360-378-2116 for building permits
 3. Obtain an access permit from Public Works if entering onto a County road
 
-## Questions?
-
-Not sure if your driveway meets requirements? [Contact us](/contact/)—we're happy to take a look and provide guidance.

--- a/src/pages/services/driveway-access.mdx
+++ b/src/pages/services/driveway-access.mdx
@@ -1,0 +1,90 @@
+---
+title: Driveway & Road Access
+nav_hidden: true
+sidebar: >
+  <div class="sidebar-block">
+    <h3 class="sidebar__heading">County Resources</h3>
+    <p><a href="https://www.codepublishing.com/WA/SanJuanCounty/html/SanJuanCounty12/SanJuanCounty1216.html" target="_blank" rel="noopener">San Juan County Code 12.16</a><br>
+    Driveway standards and requirements</p>
+    <p><a href="https://www.sanjuancountywa.gov/505/Addressing" target="_blank" rel="noopener">Address Assignment</a><br>
+    San Juan County Public Works</p>
+  </div>
+
+  <div class="sidebar-block">
+    <h3 class="sidebar__heading">Questions?</h3>
+    <p>San Juan County Community Development<br>
+    <a href="tel:360-378-2116">360-378-2116</a></p>
+    <p>San Juan County Public Works<br>
+    <a href="tel:360-370-0500">360-370-0500</a></p>
+  </div>
+---
+
+When seconds count, your driveway matters. Fire apparatus need adequate width, clearance, and a solid surface to reach your home quickly and safely. Driveways that don't meet access requirements can delay emergency response or prevent fire trucks from reaching your property at all.
+
+## Why Access Requirements Exist
+
+Our fire engines are large—some weigh over 30,000 pounds and need room to maneuver. A driveway that's too narrow, too steep, or blocked by vegetation can:
+
+* Delay response while crews find alternate access
+* Force firefighters to lay hundreds of feet of hose by hand
+* Prevent ladder trucks from reaching upper floors
+* Put both residents and firefighters at risk
+
+## Key Requirements
+
+San Juan County follows the Washington State Fire Code for fire apparatus access. Here are the essential standards:
+
+### Width and Clearance
+
+* **Minimum width:** 12 feet clear and unobstructed
+* **Vertical clearance:** 13 feet above the driveway surface
+* Trim back vegetation and tree branches regularly
+
+### Maximum Grade
+
+* **Gravel driveways:** 16% maximum grade
+* **Paved driveways:** 22% maximum grade
+
+### Turnarounds
+
+Driveways longer than **150 feet** must have an approved turnaround (cul-de-sac or hammerhead) so fire apparatus don't have to back out.
+
+* Turnarounds required at maximum 1,000-foot intervals on longer driveways
+* Must be constructed to county standards
+
+### Surface
+
+* Must support fire apparatus weight (up to 75,000 lbs for some equipment)
+* All-weather driving surface required—gravel, asphalt, or concrete
+* Properly maintained to prevent washouts and erosion
+
+### Gates
+
+If you have a gate across your driveway:
+
+* Must meet fire code requirements (Section 503.5)
+* Consider a [KnoxBox](/services/knoxbox/) so crews can enter without delay
+* Electric gates should have manual override or fail-open feature
+
+## Address Visibility
+
+Make sure your address is clearly visible from the road:
+
+* Numbers should be at least 4 inches tall
+* Contrasting colors (light on dark or dark on light)
+* Reflective numbers help at night
+* Place at driveway entrance, not just on the house
+
+Your address number is assigned by [San Juan County Public Works](https://www.sanjuancountywa.gov/505/Addressing) at 360-370-0500.
+
+## Before You Build or Modify
+
+If you're building a new driveway or making changes to an existing one:
+
+1. Contact San Juan County Community Development at 360-378-2116 to verify requirements
+2. Review [San Juan County Code 12.16](https://www.codepublishing.com/WA/SanJuanCounty/html/SanJuanCounty12/SanJuanCounty1216.html) for driveway standards
+3. Obtain an access permit if entering onto a County road
+
+## Need Help?
+
+Not sure if your driveway meets requirements? [Contact us](/contact/)—we're happy to take a look and provide guidance. It's much easier to address access issues before an emergency than during one.

--- a/src/pages/services/driveway-access.mdx
+++ b/src/pages/services/driveway-access.mdx
@@ -5,14 +5,12 @@ sidebar: >
   <div class="sidebar-block">
     <h3 class="sidebar__heading">Fire Marshal</h3>
     <p>For access requirements and fire code questions:</p>
-    <p><a href="https://www.sanjuancountywa.gov/1088/Fire-Marshal" target="_blank" rel="noopener">County Fire Marshal</a><br>
-    <a href="tel:360-378-3473">360-378-3473</a></p>
+    <p><a href="https://www.sanjuancountywa.gov/1088/Fire-Marshal" target="_blank" rel="noopener">County Fire Marshal</a></p>
   </div>
 
   <div class="sidebar-block">
     <h3 class="sidebar__heading">Address Assignment</h3>
-    <p><a href="https://www.sanjuancountywa.gov/505/Addressing" target="_blank" rel="noopener">San Juan County Public Works</a><br>
-    <a href="tel:360-370-0500">360-370-0500</a></p>
+    <p><a href="https://www.sanjuancountywa.gov/505/Addressing" target="_blank" rel="noopener">San Juan County Public Works</a></p>
   </div>
 ---
 
@@ -20,7 +18,7 @@ When seconds count, your driveway matters. Fire apparatus need adequate width, c
 
 ## Why Access Matters
 
-Our apparatus are large and heavy—our biggest weighs 54,000 pounds. A driveway that's too narrow, too steep, or blocked by vegetation can:
+Our apparatus are large and heavy—our biggest weighs 53,000 pounds. A driveway that's too narrow, too steep, or blocked by vegetation can:
 
 * Delay response while crews find alternate access
 * Force firefighters to lay hundreds of feet of hose by hand
@@ -41,13 +39,13 @@ Make sure your address is clearly visible from the road:
 * Reflective numbers help at night
 * Placed at driveway entrance, not just on the house
 
-Your address is assigned by [San Juan County Public Works](https://www.sanjuancountywa.gov/505/Addressing) at 360-370-0500.
+Your address is assigned by [San Juan County Public Works](https://www.sanjuancountywa.gov/505/Addressing).
 
 ## Before You Build or Modify
 
 If you're building a new driveway or making changes:
 
-1. Contact the [County Fire Marshal](https://www.sanjuancountywa.gov/1088/Fire-Marshal) at 360-378-3473 for fire access requirements
-2. Contact Community Development at 360-378-2116 for building permits
-3. Obtain an access permit from Public Works if entering onto a County road
+1. Contact the [County Fire Marshal](https://www.sanjuancountywa.gov/1088/Fire-Marshal) for fire access requirements
+2. Contact [Community Development](https://www.sanjuancountywa.gov/2171/Community-Development) for building permits
+3. Obtain an access permit from [Public Works](https://www.sanjuancountywa.gov/505/Addressing) if entering onto a County road
 

--- a/src/pages/services/driveway-access.mdx
+++ b/src/pages/services/driveway-access.mdx
@@ -4,18 +4,20 @@ nav_hidden: true
 sidebar: >
   <div class="sidebar-block">
     <h3 class="sidebar__heading">County Resources</h3>
-    <p><a href="https://www.codepublishing.com/WA/SanJuanCounty/html/SanJuanCounty12/SanJuanCounty1216.html" target="_blank" rel="noopener">San Juan County Code 12.16</a><br>
-    Driveway standards and requirements</p>
+    <p><a href="https://www.codepublishing.com/WA/SanJuanCounty/html/SanJuanCounty15/SanJuanCounty1504.html" target="_blank" rel="noopener">SJC Code Chapter 15.04</a><br>
+    Construction codes (includes fire code)</p>
+    <p><a href="https://www.sanjuancountywa.gov/1088/Fire-Marshal" target="_blank" rel="noopener">County Fire Marshal</a><br>
+    Fire apparatus access requirements</p>
     <p><a href="https://www.sanjuancountywa.gov/505/Addressing" target="_blank" rel="noopener">Address Assignment</a><br>
     San Juan County Public Works</p>
   </div>
 
   <div class="sidebar-block">
     <h3 class="sidebar__heading">Questions?</h3>
-    <p>San Juan County Community Development<br>
+    <p>San Juan County Fire Marshal<br>
+    <a href="tel:360-378-3473">360-378-3473</a></p>
+    <p>Community Development<br>
     <a href="tel:360-378-2116">360-378-2116</a></p>
-    <p>San Juan County Public Works<br>
-    <a href="tel:360-370-0500">360-370-0500</a></p>
   </div>
 ---
 
@@ -32,7 +34,7 @@ Our fire engines are large—some weigh over 30,000 pounds and need room to mane
 
 ## Key Requirements
 
-San Juan County follows the Washington State Fire Code for fire apparatus access. Here are the essential standards:
+San Juan County adopts the International Fire Code through [County Code Chapter 15.04](https://www.codepublishing.com/WA/SanJuanCounty/html/SanJuanCounty15/SanJuanCounty1504.html). The [County Fire Marshal](https://www.sanjuancountywa.gov/1088/Fire-Marshal) enforces these fire apparatus access requirements:
 
 ### Width and Clearance
 
@@ -81,9 +83,9 @@ Your address number is assigned by [San Juan County Public Works](https://www.sa
 
 If you're building a new driveway or making changes to an existing one:
 
-1. Contact San Juan County Community Development at 360-378-2116 to verify requirements
-2. Review [San Juan County Code 12.16](https://www.codepublishing.com/WA/SanJuanCounty/html/SanJuanCounty12/SanJuanCounty1216.html) for driveway standards
-3. Obtain an access permit if entering onto a County road
+1. Contact the [County Fire Marshal](https://www.sanjuancountywa.gov/1088/Fire-Marshal) at 360-378-3473 to verify fire access requirements
+2. Contact Community Development at 360-378-2116 for building permits
+3. Obtain an access permit from Public Works if entering onto a County road
 
 ## Need Help?
 

--- a/src/pages/services/driveway-access.mdx
+++ b/src/pages/services/driveway-access.mdx
@@ -41,11 +41,3 @@ Make sure your address is clearly visible from the road:
 
 Your address is assigned by [San Juan County Public Works](https://www.sanjuancountywa.gov/505/Addressing).
 
-## Before You Build or Modify
-
-If you're building a new driveway or making changes:
-
-1. Contact the [County Fire Marshal](https://www.sanjuancountywa.gov/1088/Fire-Marshal) for fire access requirements
-2. Contact [Community Development](https://www.sanjuancountywa.gov/2171/Community-Development) for building permits
-3. Obtain an access permit from [Public Works](https://www.sanjuancountywa.gov/505/Addressing) if entering onto a County road
-

--- a/src/pages/services/driveway-access.mdx
+++ b/src/pages/services/driveway-access.mdx
@@ -3,90 +3,55 @@ title: Driveway & Road Access
 nav_hidden: true
 sidebar: >
   <div class="sidebar-block">
-    <h3 class="sidebar__heading">County Resources</h3>
-    <p><a href="https://www.codepublishing.com/WA/SanJuanCounty/html/SanJuanCounty15/SanJuanCounty1504.html" target="_blank" rel="noopener">SJC Code Chapter 15.04</a><br>
-    Construction codes (includes fire code)</p>
+    <h3 class="sidebar__heading">Fire Marshal</h3>
+    <p>For access requirements and fire code questions:</p>
     <p><a href="https://www.sanjuancountywa.gov/1088/Fire-Marshal" target="_blank" rel="noopener">County Fire Marshal</a><br>
-    Fire apparatus access requirements</p>
-    <p><a href="https://www.sanjuancountywa.gov/505/Addressing" target="_blank" rel="noopener">Address Assignment</a><br>
-    San Juan County Public Works</p>
+    <a href="tel:360-378-3473">360-378-3473</a></p>
   </div>
 
   <div class="sidebar-block">
-    <h3 class="sidebar__heading">Questions?</h3>
-    <p>San Juan County Fire Marshal<br>
-    <a href="tel:360-378-3473">360-378-3473</a></p>
-    <p>Community Development<br>
-    <a href="tel:360-378-2116">360-378-2116</a></p>
+    <h3 class="sidebar__heading">Address Assignment</h3>
+    <p><a href="https://www.sanjuancountywa.gov/505/Addressing" target="_blank" rel="noopener">San Juan County Public Works</a><br>
+    <a href="tel:360-370-0500">360-370-0500</a></p>
   </div>
 ---
 
-When seconds count, your driveway matters. Fire apparatus need adequate width, clearance, and a solid surface to reach your home quickly and safely. Driveways that don't meet access requirements can delay emergency response or prevent fire trucks from reaching your property at all.
+When seconds count, your driveway matters. Fire apparatus need adequate width, clearance, and a solid surface to reach your home. Driveways that don't meet access requirements can delay emergency response or prevent fire trucks from reaching your property at all.
 
-## Why Access Requirements Exist
+## Why Access Matters
 
-Our fire engines are large—some weigh over 30,000 pounds and need room to maneuver. A driveway that's too narrow, too steep, or blocked by vegetation can:
+Our apparatus are large and heavy—our biggest engine weighs 54,000 pounds. A driveway that's too narrow, too steep, or blocked by vegetation can:
 
 * Delay response while crews find alternate access
 * Force firefighters to lay hundreds of feet of hose by hand
 * Prevent ladder trucks from reaching upper floors
 * Put both residents and firefighters at risk
 
-## Key Requirements
+## Access Requirements
 
-San Juan County adopts the International Fire Code through [County Code Chapter 15.04](https://www.codepublishing.com/WA/SanJuanCounty/html/SanJuanCounty15/SanJuanCounty1504.html). The [County Fire Marshal](https://www.sanjuancountywa.gov/1088/Fire-Marshal) enforces these fire apparatus access requirements:
+San Juan County adopts the International Fire Code, which sets standards for driveway width, vertical clearance, grade, turnarounds, surface strength, and gates. The [County Fire Marshal](https://www.sanjuancountywa.gov/1088/Fire-Marshal) enforces these requirements and can answer questions about your specific situation.
 
-### Width and Clearance
-
-* **Minimum width:** 12 feet clear and unobstructed
-* **Vertical clearance:** 13 feet above the driveway surface
-* Trim back vegetation and tree branches regularly
-
-### Maximum Grade
-
-* **Gravel driveways:** 16% maximum grade
-* **Paved driveways:** 22% maximum grade
-
-### Turnarounds
-
-Driveways longer than **150 feet** must have an approved turnaround (cul-de-sac or hammerhead) so fire apparatus don't have to back out.
-
-* Turnarounds required at maximum 1,000-foot intervals on longer driveways
-* Must be constructed to county standards
-
-### Surface
-
-* Must support fire apparatus weight (up to 75,000 lbs for some equipment)
-* All-weather driving surface required—gravel, asphalt, or concrete
-* Properly maintained to prevent washouts and erosion
-
-### Gates
-
-If you have a gate across your driveway:
-
-* Must meet fire code requirements (Section 503.5)
-* Consider a [KnoxBox](/services/knoxbox/) so crews can enter without delay
-* Electric gates should have manual override or fail-open feature
+**If you have a gate**, consider a [KnoxBox](/services/knoxbox/) so crews can enter without delay. Electric gates should have a manual override or fail-open feature.
 
 ## Address Visibility
 
 Make sure your address is clearly visible from the road:
 
-* Numbers should be at least 4 inches tall
+* Numbers at least 4 inches tall
 * Contrasting colors (light on dark or dark on light)
 * Reflective numbers help at night
-* Place at driveway entrance, not just on the house
+* Placed at driveway entrance, not just on the house
 
-Your address number is assigned by [San Juan County Public Works](https://www.sanjuancountywa.gov/505/Addressing) at 360-370-0500.
+Your address is assigned by [San Juan County Public Works](https://www.sanjuancountywa.gov/505/Addressing) at 360-370-0500.
 
 ## Before You Build or Modify
 
-If you're building a new driveway or making changes to an existing one:
+If you're building a new driveway or making changes:
 
-1. Contact the [County Fire Marshal](https://www.sanjuancountywa.gov/1088/Fire-Marshal) at 360-378-3473 to verify fire access requirements
+1. Contact the [County Fire Marshal](https://www.sanjuancountywa.gov/1088/Fire-Marshal) at 360-378-3473 for fire access requirements
 2. Contact Community Development at 360-378-2116 for building permits
 3. Obtain an access permit from Public Works if entering onto a County road
 
-## Need Help?
+## Questions?
 
-Not sure if your driveway meets requirements? [Contact us](/contact/)—we're happy to take a look and provide guidance. It's much easier to address access issues before an emergency than during one.
+Not sure if your driveway meets requirements? [Contact us](/contact/)—we're happy to take a look and provide guidance.

--- a/src/pages/services/education-preparedness.mdx
+++ b/src/pages/services/education-preparedness.mdx
@@ -49,6 +49,11 @@ Simple steps you can take to protect your home and help first responders.
     <h3>KnoxBox Key Access</h3>
     <p>A secure key safe that allows first responders to enter your property quickly without forced entry.</p>
   </a>
+
+  <a href="/services/driveway-access/" class="card card--link">
+    <h3>Driveway & Road Access</h3>
+    <p>Ensure fire trucks can reach your home. Learn about width, clearance, and turnaround requirements.</p>
+  </a>
 </div>
 
 ---

--- a/src/pages/services/education-preparedness.mdx
+++ b/src/pages/services/education-preparedness.mdx
@@ -2,19 +2,6 @@
 title: Education & Preparedness
 nav_order: 2
 nav_title: "Education & Preparedness"
-sidebar: >
-  <div class="sidebar-block">
-    <h3 class="sidebar__heading">Contact Us</h3>
-    <p>Have questions about any of our programs?</p>
-    <p><a href="tel:360-378-5334">360-378-5334</a><br>
-    <a href="/contact/">Send a Message</a></p>
-  </div>
-
-  <div class="sidebar-block">
-    <h3 class="sidebar__heading">Free Home Evaluation</h3>
-    <p>Our team will assess your property's wildfire risk at no cost.</p>
-    <a class="btn btn-primary" href="/contact/">Schedule Now</a>
-  </div>
 ---
 
 San Juan Island Fire & Rescue offers education and preparedness programs to help keep our community safe. From wildfire preparation to home safety equipment, we're here to help you protect what matters most.

--- a/src/pages/services/education-preparedness.mdx
+++ b/src/pages/services/education-preparedness.mdx
@@ -45,6 +45,11 @@ Simple steps you can take to protect your home and help first responders.
     <p>Working alarms save lives. Learn where to install them, how to maintain them, and when to replace them.</p>
   </a>
 
+  <a href="/services/fire-extinguishers/" class="card card--link">
+    <h3>Fire Extinguishers</h3>
+    <p>Choose the right extinguisher, learn the PASS technique, and know when to fight a fire vs. evacuate.</p>
+  </a>
+
   <a href="/services/knoxbox/" class="card card--link">
     <h3>KnoxBox Key Access</h3>
     <p>A secure key safe that allows first responders to enter your property quickly without forced entry.</p>

--- a/src/pages/services/education-preparedness.mdx
+++ b/src/pages/services/education-preparedness.mdx
@@ -31,7 +31,7 @@ Living in the San Juan Islands means living in a wildland-urban interface. These
 
   <a href="/services/firewise/" class="card card--link">
     <h3>Firewise USA</h3>
-    <p>Learn about defensible space and join one of San Juan County's 33 Firewise communities. Free property evaluations available.</p>
+    <p>A national program helping neighborhoods work together to reduce wildfire risk. San Juan County has 33 recognized Firewise communities.</p>
   </a>
 </div>
 
@@ -57,7 +57,7 @@ Simple steps you can take to protect your home and help first responders.
 
   <a href="/services/driveway-access/" class="card card--link">
     <h3>Driveway & Road Access</h3>
-    <p>Ensure fire trucks can reach your home. Learn about width, clearance, and turnaround requirements.</p>
+    <p>Our apparatus weigh up to 53,000 pounds. Make sure they can reach your home.</p>
   </a>
 </div>
 

--- a/src/pages/services/education-preparedness.mdx
+++ b/src/pages/services/education-preparedness.mdx
@@ -1,0 +1,56 @@
+---
+title: Education & Preparedness
+nav_order: 3
+nav_title: "Education & Preparedness"
+sidebar: >
+  <div class="sidebar-block">
+    <h3 class="sidebar__heading">Contact Us</h3>
+    <p>Have questions about any of our programs?</p>
+    <p><a href="tel:360-378-5334">360-378-5334</a><br>
+    <a href="/contact/">Send a Message</a></p>
+  </div>
+
+  <div class="sidebar-block">
+    <h3 class="sidebar__heading">Free Home Evaluation</h3>
+    <p>Our team will assess your property's wildfire risk at no cost.</p>
+    <a class="btn btn-primary" href="/contact/">Schedule Now</a>
+  </div>
+---
+
+San Juan Island Fire & Rescue offers education and preparedness programs to help keep our community safe. From wildfire preparation to home safety equipment, we're here to help you protect what matters most.
+
+## Wildfire Preparedness
+
+Living in the San Juan Islands means living in a wildland-urban interface. These programs help you prepare your home and property for wildfire season.
+
+<div class="card-grid">
+  <a href="/services/wildfire-ready/" class="card card--link">
+    <h3>Wildfire Ready Neighbors</h3>
+    <p>Get a free personalized action plan from Washington DNR to prepare your property for wildfire. Optional home visits available.</p>
+  </a>
+
+  <a href="/services/firewise/" class="card card--link">
+    <h3>Firewise USA</h3>
+    <p>Learn about defensible space and join one of San Juan County's 33 Firewise communities. Free property evaluations available.</p>
+  </a>
+</div>
+
+## Home Safety
+
+Simple steps you can take to protect your home and help first responders.
+
+<div class="card-grid">
+  <a href="/services/fire-alarms/" class="card card--link">
+    <h3>Smoke and CO Alarms</h3>
+    <p>Working alarms save lives. Learn where to install them, how to maintain them, and when to replace them.</p>
+  </a>
+
+  <a href="/services/knoxbox/" class="card card--link">
+    <h3>KnoxBox Key Access</h3>
+    <p>A secure key safe that allows first responders to enter your property quickly without forced entry.</p>
+  </a>
+</div>
+
+---
+
+*Questions about any of these programs? [Contact us](/contact/) anytime—we're happy to help.*

--- a/src/pages/services/education-preparedness.mdx
+++ b/src/pages/services/education-preparedness.mdx
@@ -1,6 +1,6 @@
 ---
 title: Education & Preparedness
-nav_order: 3
+nav_order: 2
 nav_title: "Education & Preparedness"
 sidebar: >
   <div class="sidebar-block">

--- a/src/pages/services/fire-alarms.mdx
+++ b/src/pages/services/fire-alarms.mdx
@@ -2,6 +2,7 @@
 title: Smoke and Carbon Monoxide Alarms
 nav_order: 8
 nav_title: "Smoke and CO Alarms"
+nav_hidden: true
 sidebar: ''
 ---
 

--- a/src/pages/services/fire-extinguishers.mdx
+++ b/src/pages/services/fire-extinguishers.mdx
@@ -1,0 +1,131 @@
+---
+title: Fire Extinguishers
+nav_hidden: true
+sidebar: >
+  <div class="sidebar-block">
+    <h3 class="sidebar__heading">The PASS Technique</h3>
+    <p><strong>P</strong>ull the pin<br>
+    <strong>A</strong>im at the base of the fire<br>
+    <strong>S</strong>queeze the handle<br>
+    <strong>S</strong>weep side to side</p>
+  </div>
+
+  <div class="sidebar-block">
+    <h3 class="sidebar__heading">When to Evacuate</h3>
+    <p>Get out immediately if:</p>
+    <ul>
+      <li>The fire is spreading</li>
+      <li>The room is filling with smoke</li>
+      <li>You can't reach an exit</li>
+      <li>Your extinguisher is empty</li>
+    </ul>
+  </div>
+
+  <div class="sidebar-block">
+    <h3 class="sidebar__heading">Questions?</h3>
+    <p><a href="/contact/">Contact us</a> for fire safety guidance.</p>
+  </div>
+---
+
+A portable fire extinguisher can save lives and property by putting out a small fire or containing it until the fire department arrives. But you need the right type, you need to know how to use it, and you need to know when to leave the fire to us.
+
+## Know Before You Go
+
+**Only attempt to fight a fire if:**
+
+* Everyone has evacuated or is evacuating
+* Someone has called 911
+* The fire is small and contained (like a wastebasket)
+* You have a clear escape route behind you
+* You have the right type of extinguisher
+* You know how to use it
+
+**If any of these aren't true—get out and call 911.** Your safety is more important than any property.
+
+## Fire Classes
+
+Different fires require different extinguishers. Using the wrong type can be ineffective or dangerous.
+
+| Class | What's Burning | Examples |
+|-------|---------------|----------|
+| **A** | Ordinary combustibles | Paper, wood, cloth, plastic |
+| **B** | Flammable liquids | Gasoline, oil, paint, solvents |
+| **C** | Electrical equipment | Appliances, motors, wiring |
+| **K** | Cooking oils/grease | Kitchen fires (commercial) |
+
+## Choosing an Extinguisher for Your Home
+
+### ABC Multi-Purpose (Recommended for Most Homes)
+
+An **ABC-rated extinguisher** handles the most common household fires—paper, wood, flammable liquids, and electrical. This is the best all-around choice for home use.
+
+**Look for:** A minimum rating of **2-A:10-B:C**
+
+* The number before "A" indicates capacity for ordinary combustibles
+* The number before "B" indicates capacity for flammable liquids
+* "C" means it's safe for electrical fires (no number rating)
+
+### Kitchen Extinguishers
+
+For kitchens, consider a **Class K or BC extinguisher** specifically rated for grease fires. Never use water on a grease fire—it will cause the fire to spread violently.
+
+**Tip:** A lid or baking sheet can smother a small pan fire. Turn off the heat and cover the pan.
+
+## Where to Place Extinguishers
+
+NFPA recommends at least one extinguisher on every level of your home:
+
+* **Kitchen** — Near the exit, not directly next to the stove
+* **Garage** — Where flammable liquids are stored
+* **Bedroom hallway** — For quick access at night
+* **Workshop/basement** — Near the exit
+
+Mount extinguishers where they're visible and accessible, ideally near exits so you can escape if the fire grows.
+
+## How to Use an Extinguisher (PASS)
+
+Remember **PASS**:
+
+1. **Pull** the pin — This unlocks the handle
+2. **Aim** at the base of the fire — Not the flames
+3. **Squeeze** the handle — This releases the agent
+4. **Sweep** side to side — Cover the entire base of the fire
+
+Stand 6-8 feet away. Most extinguishers discharge for only 10-20 seconds, so aim carefully.
+
+## Inspection and Maintenance
+
+Fire extinguishers need regular attention:
+
+**Monthly:**
+* Check that it's in its designated place
+* Verify the pressure gauge is in the green zone
+* Look for visible damage, rust, or leakage
+* Ensure the pin and tamper seal are intact
+
+**Annually:**
+* Have extinguishers professionally inspected
+
+**Replace:**
+* Disposable extinguishers: every 12 years
+* Rechargeable extinguishers: after each use (have them serviced)
+* Any extinguisher that fails inspection
+
+## After Any Fire
+
+Even if you put out a small fire yourself:
+
+1. **Call 911** — Let us verify the fire is completely out
+2. **Evacuate** — Hidden embers can reignite
+3. **Don't re-enter** — Wait for firefighters to clear the scene
+
+Fires can smolder inside walls or ceilings. We have thermal cameras to check for hidden hot spots.
+
+## Resources
+
+* [NFPA Fire Extinguisher Information](https://www.nfpa.org/education-and-research/home-fire-safety/fire-extinguishers)
+* [FEMA: Choosing and Using Fire Extinguishers](https://www.usfa.fema.gov/prevention/home-fires/prepare-for-fire/fire-extinguishers/)
+
+---
+
+*Questions about fire extinguishers or home fire safety? [Contact us](/contact/)—we're happy to help.*

--- a/src/pages/services/firewise.mdx
+++ b/src/pages/services/firewise.mdx
@@ -1,6 +1,7 @@
 ---
 title: Firewise
-nav_order: 6
+nav_order: 3
+nav_hidden: true
 sidebar: >
   ![Defensible Space Zones](/assets/media/firewise_space.png "Defensible Space Zones")
 

--- a/src/pages/services/knoxbox.mdx
+++ b/src/pages/services/knoxbox.mdx
@@ -2,6 +2,7 @@
 title: "KnoxBox Key Access"
 nav_order: 7
 nav_title: "KnoxBox"
+nav_hidden: true
 ---
 
 <StyledImage src="/assets/media/knoxbox.png" alt="Residential KnoxBox" size="medium" align="center" />

--- a/src/pages/services/marine.mdx
+++ b/src/pages/services/marine.mdx
@@ -1,6 +1,6 @@
 ---
 title: Marine Response
-nav_order: 3
+nav_order: 4
 sidebar: >
   <div class="sidebar-block">
     <h3 class="sidebar__heading">Contact</h3>

--- a/src/pages/services/outer-island-brigades.mdx
+++ b/src/pages/services/outer-island-brigades.mdx
@@ -1,6 +1,6 @@
 ---
 title: Outer Island Brigades
-nav_order: 2
+nav_order: 3
 sidebar: >
   <div class="sidebar-block">
     <h3 class="sidebar__heading">Join the Brigade</h3>

--- a/src/pages/services/wildfire-ready.mdx
+++ b/src/pages/services/wildfire-ready.mdx
@@ -1,6 +1,7 @@
 ---
 title: Wildfire Ready
-nav_order: 5
+nav_order: 2
+nav_hidden: true
 sidebar: >
   ![Defensible Space Zones](/assets/media/dnr_defensible_space_zones.png "Defensible Space Zones")
 


### PR DESCRIPTION
Create a new landing page that organizes wildfire preparedness and home safety resources. Child pages (Wildfire Ready, Firewise, Smoke/CO Alarms, KnoxBox) are now hidden from the main dropdown and accessible through this landing page.

- Add education-preparedness.mdx with card grid linking to child pages
- Add card-grid and card--link CSS styles for the landing page layout
- Set nav_hidden: true on the 4 child pages to hide from dropdown