### PR TITLE
Add Volunteer Association page

### DIFF
--- a/src/pages/about/volunteer-association.mdx
+++ b/src/pages/about/volunteer-association.mdx
@@ -44,12 +44,14 @@ We collaborate with local organizations to serve our community:
 - Island Rec
 - Joyce L. Sobel Family Resource Center
 
+<!--
 ## Youth & Education
 
 The Association is committed to investing in the next generation:
 
 - **High School Scholarship Fund** — annual scholarship for graduating seniors
 - **Fire Wise with Scholars** — supporting high school volunteers in the fire service
+-->
 
 ## How You Can Help
 
@@ -57,4 +59,6 @@ The Association is funded through community support:
 
 - [Friday Harbor Firefighters Thrift House](https://www.facebook.com/p/Friday-Harbor-Thrift-Store-100063570461877/) — 667 Mullis St, Friday Harbor
 - Private donations from local benefactors
+<!--
 - Fire department merchandise *(coming soon)*
+-->

--- a/src/pages/about/volunteer-association.mdx
+++ b/src/pages/about/volunteer-association.mdx
@@ -1,0 +1,44 @@
+---
+title: "Volunteer Association"
+nav_order: 3
+layout: page
+sidebar: |
+  <div class="sidebar-block">
+    <styled-image src="/assets/media/gallery/Easter Bunny for Firefighers Association Event.jpg" alt="Easter Bunny at Firefighters Association Event" size="full" />
+  </div>
+  <div class="sidebar-block">
+    <styled-image src="/assets/media/easter_bunny_2021.png" alt="Easter Celebration 2021" size="full" />
+  </div>
+---
+
+The purpose of this Association shall be to function as an auxiliary to San Juan County Fire District #3. The primary mission of the Association is to support and recognize the work and dedication of District #3 firefighters.
+
+## Community Events
+
+We offer community opportunities for celebration and gathering:
+
+- Easter Celebration at Jackson Beach
+- Support for Halloween by providing candy and lighting
+
+## How We Are Supported
+
+- [Friday Harbor Firefighters Thrift House](https://www.facebook.com/p/Friday-Harbor-Thrift-Store-100063570461877/) located at 667 Mullis St, Friday Harbor, WA 98250
+- Private donations from local benefactors
+- Future availability of Fire SWAG for purchase by the public
+
+## Community Partners
+
+We partner with the following agencies in bringing community functions:
+
+- EMS
+- Sheriff's Office
+- Library
+- Island Rec
+- Joyce L. Sobel Family Resource Center
+
+## Youth Programs
+
+The Association is also gearing up to offer:
+
+- High School Scholarship Fund (one per year)
+- Support for High School volunteers through Fire Wise with Scholars

--- a/src/pages/about/volunteer-association.mdx
+++ b/src/pages/about/volunteer-association.mdx
@@ -7,38 +7,54 @@ sidebar: |
     <styled-image src="/assets/media/gallery/Easter Bunny for Firefighers Association Event.jpg" alt="Easter Bunny at Firefighters Association Event" size="full" />
   </div>
   <div class="sidebar-block">
-    <styled-image src="/assets/media/easter_bunny_2021.png" alt="Easter Celebration 2021" size="full" />
+    <styled-image src="/assets/media/gallery/family.jpg" alt="Firefighter family at community event" size="full" />
+  </div>
+  <div class="sidebar-block">
+    <styled-image src="/assets/media/easter_bunny_2021.png" alt="Easter Celebration at Jackson Beach" size="full" />
+  </div>
+  <div class="sidebar-block">
+    <styled-image src="/assets/media/gallery/teammates.jpg" alt="SJIFR teammates" size="full" />
   </div>
 ---
 
-The purpose of this Association shall be to function as an auxiliary to San Juan County Fire District #3. The primary mission of the Association is to support and recognize the work and dedication of District #3 firefighters.
+The San Juan Island Firefighters Volunteer Association serves as an auxiliary to San Juan County Fire District #3. Our mission is to support and recognize the dedication of District #3 firefighters while strengthening the connection between the fire service and the community we serve.
 
-## Community Events
+## Supporting Our Firefighters
 
-We offer community opportunities for celebration and gathering:
+The Association provides direct support to the men and women who protect our community:
 
-- Easter Celebration at Jackson Beach
-- Support for Halloween by providing candy and lighting
+- **Hardship Grants** for members facing unexpected financial challenges
+- **Educational Grants** to support professional development and training
+- **Gear Stipends** for equipment not covered by the department
 
-## How We Are Supported
+## Community Celebrations
 
-- [Friday Harbor Firefighters Thrift House](https://www.facebook.com/p/Friday-Harbor-Thrift-Store-100063570461877/) located at 667 Mullis St, Friday Harbor, WA 98250
-- Private donations from local benefactors
-- Future availability of Fire SWAG for purchase by the public
+We bring our community together through seasonal events:
+
+- **Easter Celebration at Jackson Beach** — an annual tradition for island families
+- **Halloween Support** — providing candy and lighting for safe trick-or-treating
 
 ## Community Partners
 
-We partner with the following agencies in bringing community functions:
+We collaborate with local organizations to serve our community:
 
-- EMS
-- Sheriff's Office
-- Library
+- San Juan Island EMS
+- San Juan County Sheriff's Office
+- San Juan Island Library
 - Island Rec
 - Joyce L. Sobel Family Resource Center
 
-## Youth Programs
+## Youth & Education
 
-The Association is also gearing up to offer:
+The Association is committed to investing in the next generation:
 
-- High School Scholarship Fund (one per year)
-- Support for High School volunteers through Fire Wise with Scholars
+- **High School Scholarship Fund** — annual scholarship for graduating seniors
+- **Fire Wise with Scholars** — supporting high school volunteers in the fire service
+
+## How You Can Help
+
+The Association is funded through community support:
+
+- [Friday Harbor Firefighters Thrift House](https://www.facebook.com/p/Friday-Harbor-Thrift-Store-100063570461877/) — 667 Mullis St, Friday Harbor
+- Private donations from local benefactors
+- Fire department merchandise *(coming soon)*


### PR DESCRIPTION
## Summary

- Adds new "Volunteer Association" page under the About section
- Two-column layout with four sidebar images (Easter events, family, teammates)
- Content includes:
  - Mission statement as auxiliary to District #3
  - **Firefighter support programs**: hardship grants, educational grants, gear stipends
  - Community celebrations (Easter at Jackson Beach, Halloween)
  - Community partners (EMS, Sheriff, Library, Island Rec, Sobel Center)
  - Youth & education programs (scholarship fund, Fire Wise with Scholars)
  - Funding sources (Thrift House, donations, future merchandise)

## Test plan

- [ ] Verify page renders at `/about/volunteer-association/`
- [ ] Confirm two-column layout displays correctly
- [ ] Check all four images load in sidebar
- [ ] Verify page appears in About navigation menu