### PR TITLE
fix: CSS float for styled images

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1721,15 +1721,24 @@ select.form-control:focus::-ms-value {
   margin-top: 0.5rem;
 }
 
-/* Sizes */
-.block-content .styled-image--small img { max-width: 25%; }
-.block-content .styled-image--medium img { max-width: 50%; }
-.block-content .styled-image--large img { max-width: 75%; }
-.block-content .styled-image--full img { max-width: 100%; }
+/* Sizes - constrain both figure and img for proper floating */
+.block-content .styled-image--small { max-width: 25%; }
+.block-content .styled-image--medium { max-width: 50%; }
+.block-content .styled-image--large { max-width: 75%; }
+.block-content .styled-image--full { max-width: 100%; }
+
+.block-content .styled-image--small img,
+.block-content .styled-image--medium img,
+.block-content .styled-image--large img,
+.block-content .styled-image--full img {
+  max-width: 100%;
+}
 
 /* Alignment */
 .block-content .styled-image--center {
   text-align: center;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .block-content .styled-image--center img {

--- a/src/pages/services/marine.mdx
+++ b/src/pages/services/marine.mdx
@@ -47,13 +47,13 @@ The vessel navigates with Garmin chart plotter, RADAR, AIS, and portable thermal
 
 ### Search and Rescue
 
-<StyledImage src="/assets/media/fireboat_bow_door.jpg" alt="Fireboat 31 with hydraulic bow door lowered for beach landing" align="right" size="medium" />
+<StyledImage src="/assets/media/fireboat_bow_door.jpg" alt="Fireboat 31 with hydraulic bow door lowered for beach landing" size="large" align="center" />
 
 With powerful spotlights and inertially stabilized binoculars, our crew can run search patterns in most weather conditions. A hydraulic bow door with steps facilitates retrieving victims from the water or transferring patients from docks. The cabin includes a long bench for patient transport in a Stokes litter.
 
 ### Fire Suppression
 
-<StyledImage src="/assets/media/fireboat_water_monitor.jpg" alt="Fireboat 31 water monitor demonstrating fire suppression capability" align="right" size="medium" />
+<StyledImage src="/assets/media/fireboat_water_monitor.jpg" alt="Fireboat 31 water monitor demonstrating fire suppression capability" size="large" align="center" />
 
 A stern-mounted Darley 37-HP water pump powers our firefighting capability:
 * **500 gpm at 30 psi** or **300 gpm at 100 psi**
@@ -89,7 +89,7 @@ We use GAR (Green-Amber-Red) scoring to evaluate risk versus gain before accepti
 
 ## Service Area
 
-<StyledImage src="/assets/media/fireboat_wildland_transport.jpg" alt="Wildland firefighters preparing to board Fireboat 31" align="right" size="medium" />
+<StyledImage src="/assets/media/fireboat_wildland_transport.jpg" alt="Wildland firefighters preparing to board Fireboat 31" size="large" align="center" />
 
 San Juan Island Fire & Rescue marine crew responds to threats to life, property, and the environment within our district and its waterways. Responses outside the district require fire chief authorization and appropriate interagency agreements.
 

--- a/src/pages/services/marine.mdx
+++ b/src/pages/services/marine.mdx
@@ -47,13 +47,13 @@ The vessel navigates with Garmin chart plotter, RADAR, AIS, and portable thermal
 
 ### Search and Rescue
 
-<StyledImage src="/assets/media/fireboat_bow_door.jpg" alt="Fireboat 31 with hydraulic bow door lowered for beach landing" size="large" align="center" />
+<StyledImage src="/assets/media/fireboat_bow_door.jpg" alt="Fireboat 31 with hydraulic bow door lowered for beach landing" size="medium" align="right" />
 
 With powerful spotlights and inertially stabilized binoculars, our crew can run search patterns in most weather conditions. A hydraulic bow door with steps facilitates retrieving victims from the water or transferring patients from docks. The cabin includes a long bench for patient transport in a Stokes litter.
 
 ### Fire Suppression
 
-<StyledImage src="/assets/media/fireboat_water_monitor.jpg" alt="Fireboat 31 water monitor demonstrating fire suppression capability" size="large" align="center" />
+<StyledImage src="/assets/media/fireboat_water_monitor.jpg" alt="Fireboat 31 water monitor demonstrating fire suppression capability" size="medium" align="right" />
 
 A stern-mounted Darley 37-HP water pump powers our firefighting capability:
 * **500 gpm at 30 psi** or **300 gpm at 100 psi**
@@ -89,7 +89,7 @@ We use GAR (Green-Amber-Red) scoring to evaluate risk versus gain before accepti
 
 ## Service Area
 
-<StyledImage src="/assets/media/fireboat_wildland_transport.jpg" alt="Wildland firefighters preparing to board Fireboat 31" size="large" align="center" />
+<StyledImage src="/assets/media/fireboat_wildland_transport.jpg" alt="Wildland firefighters preparing to board Fireboat 31" size="medium" align="right" />
 
 San Juan Island Fire & Rescue marine crew responds to threats to life, property, and the environment within our district and its waterways. Responses outside the district require fire chief authorization and appropriate interagency agreements.
 


### PR DESCRIPTION
## Summary
Fix CSS so that `size=\"medium\"` (or small/large) images with `align=\"right\"` or `align=\"left\"` properly float with text wrapping around them.

## The Problem
The size classes only constrained the `img` element, but the `figure` container was still 100% wide, blocking text from wrapping.

## The Fix
Apply size constraints to the `figure` element itself, not just the `img` inside:

```css
/* Before (broken) */
.styled-image--medium img { max-width: 50%; }

/* After (fixed) */
.styled-image--medium { max-width: 50%; }
.styled-image--medium img { max-width: 100%; }
```

## Test
Marine Response page (`/services/marine/`) now has images floating right with text wrapping properly.