### PR TITLE
chore: link Emergency Services to Marine Response page

### DIFF
--- a/src/pages/services/emergency-services.mdx
+++ b/src/pages/services/emergency-services.mdx
@@ -57,19 +57,11 @@ Our personnel maintain certifications in structural firefighting, wildland firef
 
 ### Marine Response
 
-As an island community surrounded by the waters of the Salish Sea, marine emergencies are a critical part of our mission. SJIF\&R operates the only fire boat in San Juan County, capable of reaching incidents throughout our waterways.
+As an island community surrounded by the waters of the Salish Sea, marine emergencies are a critical part of our mission. SJIF\&R operates [Fireboat 31](/services/marine/), the only fire boat in San Juan County, providing 24/7 response to maritime emergencies including boat fires, vessels in distress, water rescue, and medical transport from the outer islands.
 
-<StyledImage src="/assets/media/20210722-_mg_6797.jpg" alt="SJIF&R marine response vessel on patrol in the Salish Sea" align="center" />
+<StyledImage src="/assets/media/gallery/fire_boat_31.JPG" alt="Fireboat 31 on the water" align="center" />
 
-Our marine response capabilities include:
-
-* Boat fires
-* Vessels in distress
-* Water rescue operations
-* Medical emergencies on the water
-* Support for US Coast Guard operations
-
-We maintain close working relationships with US Coast Guard Station Bellingham and other maritime agencies to ensure rapid, coordinated responses to marine emergencies.
+[Learn more about our Marine Response program →](/services/marine/)
 
 ### Vehicle Extrication
 

--- a/src/pages/services/marine.mdx
+++ b/src/pages/services/marine.mdx
@@ -68,7 +68,7 @@ Fireboat 31 is designed as an emergency medical transport vessel, providing rapi
 
 ### Environmental Response
 
-Fireboat 31 serves as a first-on-scene resource for oil spills and vessel sinkings, communicating conditions and coordinating response efforts. We maintain an MOU with the Island Oil Spill Association (IOSA) to support environmental disaster response.
+Fireboat 31 serves as a first-on-scene resource for oil spills and vessel sinkings, communicating conditions and coordinating response efforts. We maintain an MOU with the [Islands' Oil Spill Association (IOSA)](https://www.iosaonline.org/) to support environmental disaster response.
 
 ---
 
@@ -95,7 +95,7 @@ San Juan Island Fire & Rescue marine crew responds to threats to life, property,
 
 Fireboat 31 regularly transports firefighters and equipment to the outer islands, supporting our [Outer Island Brigades](/services/outer-island-brigades/) program. At 40 knots, the boat can travel 20 nautical miles in 30 minutes, allowing rapid response to maritime emergencies throughout San Juan County.
 
-We maintain close working relationships with US Coast Guard Station Bellingham and other maritime agencies to ensure rapid, coordinated responses to marine emergencies.
+We maintain close working relationships with [US Coast Guard Sector Puget Sound](https://www.pacificarea.uscg.mil/Our-Organization/District-13/Units/Sector-Puget-Sound/) and other maritime agencies to ensure rapid, coordinated responses to marine emergencies.
 
 ---
 

--- a/src/pages/services/marine.mdx
+++ b/src/pages/services/marine.mdx
@@ -95,6 +95,8 @@ San Juan Island Fire & Rescue marine crew responds to threats to life, property,
 
 Fireboat 31 regularly transports firefighters and equipment to the outer islands, supporting our [Outer Island Brigades](/services/outer-island-brigades/) program. At 40 knots, the boat can travel 20 nautical miles in 30 minutes, allowing rapid response to maritime emergencies throughout San Juan County.
 
+We maintain close working relationships with US Coast Guard Station Bellingham and other maritime agencies to ensure rapid, coordinated responses to marine emergencies.
+
 ---
 
 ## Requesting Marine Response


### PR DESCRIPTION
## Summary
Condense the Marine Response section on the Emergency Services page and link to the dedicated `/services/marine/` page as the main source of truth.

## Changes
- Shortened Marine Response description to a brief summary
- Added inline link to Fireboat 31 / Marine Response page
- Added "Learn more" call-to-action link
- Updated image to use the main Fireboat 31 photo