### PR TITLE
chore: update Outer Island Brigades page content

### DIFF
--- a/src/pages/services/outer-island-brigades.mdx
+++ b/src/pages/services/outer-island-brigades.mdx
@@ -21,15 +21,15 @@ sidebar: >
   </div>
 ---
 
-**The Outer Island Brigade Program brings emergency response capabilities to the remote islands in our district.** Community members receive training in basic firefighting and medical skills, enabling them to provide critical initial response while waiting for additional resources to arrive.
+**The Outer Island Brigade Program brings emergency response capabilities to the remote islands in our district.** Community members receive training in basic firefighting, remote medical skills, and much more, enabling them to provide critical initial response while awaiting arrival of additional resources.
 
 <StyledImage src="/assets/media/brigade_rescue_training.jpg" alt="Brigade members receiving rescue training" align="center" />
 
 ## About the Program
 
-San Juan Island Fire & Rescue's Outer Island Division works with community members on islands throughout our district to develop small brigades equipped with response vehicles and equipment. We also welcome community members who prefer support roles during incidents.
+San Juan Island Fire & Rescue's Outer Island Division works with community members on remote islands within our district to develop small brigades equipped with response vehicles and equipment. We also welcome community members who provide support roles during incidents.
 
-**We've been doing this for over a decade.** Our partnerships with Waldron and Decatur Islands over the past 10+ years have trained more than 100 community members in basic firefighting and medical skills. Since 2024, we've had over 100 additional community members sign up across the outer islands.
+Since 2024, we've had over 100 community members sign up within the outer islands.
 
 <StyledImage src="/assets/media/brigade_utv_equipment.jpg" alt="Brigade members in wildland gear learning about UTV fire suppression equipment" size="large" align="center" />
 
@@ -37,9 +37,15 @@ San Juan Island Fire & Rescue's Outer Island Division works with community membe
 
 ## What Brigade Members Do
 
+Brigade members respond to local incidents and provide initial stabilization until additional resources arrive. Incidents include but are not limited to:
+
+* Medical incidents
+* Wildfires
+* Structure and vehicle fires
+* Boating accidents
+
 Depending on your interest and availability, you can participate in various ways:
 
-* **Emergency Response** — Respond to local incidents and provide initial stabilization until additional resources arrive
 * **Fire Suppression** — Basic wildland firefighting techniques and equipment operation
 * **Medical Support** — First aid and initial medical care
 * **Community Support** — Assist during incidents without direct emergency response roles
@@ -50,14 +56,16 @@ Depending on your interest and availability, you can participate in various ways
 
 ## Training Program
 
-We schedule multiple training sessions throughout the year, giving community members the knowledge, skills, and ability to respond effectively and safely to local incidents.
+Training sessions are scheduled throughout the spring and summer season, giving community members the knowledge, skills, and ability to respond effectively and safely to local incidents.
 
-**For full brigade involvement:**
+Brigade members complete eight different training modules, ensuring they are equipped and prepared to respond to the occasional incident.
+
+**If you have interest in full brigade involvement:**
 
 1. **Submit an application** — Once approved, you're covered under SJIF&R insurance for liability and injury
 2. **Complete online FEMA courses** — Two courses on incident management
-3. **Attend in-person training** — 6-8 half-day modules held largely on local islands
-4. **Optional medical training** — Basic and advanced remote medical training available annually
+3. **Attend in-person training** — 6-8 half-day modules held largely on outer islands
+4. **Attend remote medical training** — Advanced remote medical training available annually
 
 ---
 
@@ -66,13 +74,13 @@ We schedule multiple training sessions throughout the year, giving community mem
 Beyond emergency response, our brigade program includes:
 
 * Training outer island community brigade responders and support members
-* Fire extinguisher training and defensible space education at community gatherings
-* Cooperative work with WA State Parks to mitigate beach fires
+* Community fire extinguisher training and defensible space education at community gatherings
+* Work with WA State Parks to mitigate beach fires
 * Defensible space assessments through the [WA DNR Wildfire Ready Neighbors](/services/wildfire-ready/) program
 
 ---
 
-## How to Join
+## How to Join Your Community Brigade Program
 
 The process to join SJIF&R as a community brigade member is straightforward:
 
@@ -91,13 +99,9 @@ The process to join SJIF&R as a community brigade member is straightforward:
 The Outer Island Division provides coverage to multiple islands within San Juan County Fire District 3, including:
 
 * Brown Island
-* Crane Island
-* Decatur Island
 * Henry Island
 * Johns Island
-* Pearl Island
-* Spieden Island
 * Stuart Island
-* Waldron Island
+* Spieden Island
 
 Interested in starting a brigade on your island? [Contact us](/contact/) to discuss how we can work together.

--- a/src/pages/services/outer-island-brigades.mdx
+++ b/src/pages/services/outer-island-brigades.mdx
@@ -39,6 +39,13 @@ Since 2024, we've had over 100 community members sign up within the outer island
 
 Brigade members respond to local incidents and provide initial stabilization until additional resources arrive. Incidents include but are not limited to:
 
+* Medical incidents
+* Wildfires
+* Structure and vehicle fires
+* Boating accidents
+
+Depending on your interest and availability, you can participate in various ways:
+
 * **Fire Suppression** — Basic wildland firefighting techniques and equipment operation
 * **Medical Support** — First aid and initial medical care
 * **Community Support** — Assist during incidents without direct emergency response roles
@@ -55,7 +62,7 @@ Brigade members complete eight different training modules, ensuring they are equ
 
 **If you have interest in brigade involvement:**
 
-1. **Submit an application** — Once approved, you're covered under SJIF&R insurance for liability and injury
+1. **Submit an application**
 2. **Complete online FEMA courses** — Two courses on incident management
 3. **Attend in-person training** — 6-8 half-day modules held largely on outer islands
 4. **Attend remote medical training** — Advanced remote medical training available annually
@@ -76,7 +83,7 @@ Brigade members complete eight different training modules, ensuring they are equ
 The process to join SJIF&R as a community brigade member is straightforward:
 
 1. **[Submit an application](https://forms.office.com/pages/responsepage.aspx?id=j4QiQRfDZ0KcB3xQQVDRva2d14yWAXNFl-Q6Prz2fIRUOFNSWEYyUEsxS0dFNVpITkdEWFg3RklHWCQlQCN0PWcu&route=shorturl)** — Complete the online form
-2. Once approved, you're covered under SJIF&R insurance
+2. Once approved, and training has been completed, you're covered under SJIF&R insurance
 3. Each island brigade has a coordinator as the primary point of contact
 
 **Questions about the application process?** Contact Training Officer Karl Kuetzing at [kkuetzing@sjifire.org](mailto:kkuetzing@sjifire.org) or [360-378-5334](tel:360-378-5334).

--- a/src/pages/services/outer-island-brigades.mdx
+++ b/src/pages/services/outer-island-brigades.mdx
@@ -11,8 +11,7 @@ sidebar: >
   <div class="sidebar-block">
     <h3 class="sidebar__heading">Contact</h3>
     <p><strong>Training Officer Karl Kuetzing</strong><br>
-    <a href="mailto:kkuetzing@sjifire.org">kkuetzing@sjifire.org</a><br>
-    <a href="tel:360-378-5334">360-378-5334</a></p>
+    <a href="mailto:kkuetzing@sjifire.org">kkuetzing@sjifire.org</a></p>
   </div>
 
   <div class="sidebar-block">
@@ -56,9 +55,11 @@ Depending on your interest and availability, you can participate in various ways
 
 ## Training Program
 
-Training sessions are scheduled throughout the spring and summer season, giving community members the knowledge, skills, and ability to respond effectively and safely to local incidents.
+Training sessions are scheduled throughout the spring and summer season, giving community members the knowledge, skills, and ability to respond effectively and safely to local incidents. Training includes:
 
-Brigade members complete eight different training modules, ensuring they are equipped and prepared to respond to the occasional incident. Training includes two online FEMA courses on incident management, 6-8 half-day in-person modules held largely on outer islands, and advanced remote medical training available annually.
+* Two online FEMA courses on incident management
+* 6-8 half-day in-person modules held largely on outer islands
+* Advanced remote medical training available annually
 
 ---
 
@@ -79,7 +80,7 @@ The process to join SJIF&R as a community brigade member is straightforward:
 2. Once approved, and training has been completed, you're covered under SJIF&R insurance
 3. Each island brigade has a coordinator as the primary point of contact
 
-**Questions about the application process?** Contact Training Officer Karl Kuetzing at [kkuetzing@sjifire.org](mailto:kkuetzing@sjifire.org) or [360-378-5334](tel:360-378-5334).
+**Questions about the application process?** Contact Training Officer Karl Kuetzing at [kkuetzing@sjifire.org](mailto:kkuetzing@sjifire.org).
 
 ---
 

--- a/src/pages/services/outer-island-brigades.mdx
+++ b/src/pages/services/outer-island-brigades.mdx
@@ -58,14 +58,7 @@ Depending on your interest and availability, you can participate in various ways
 
 Training sessions are scheduled throughout the spring and summer season, giving community members the knowledge, skills, and ability to respond effectively and safely to local incidents.
 
-Brigade members complete eight different training modules, ensuring they are equipped and prepared to respond to the occasional incident.
-
-**If you have interest in brigade involvement:**
-
-1. **Submit an application**
-2. **Complete online FEMA courses** — Two courses on incident management
-3. **Attend in-person training** — 6-8 half-day modules held largely on outer islands
-4. **Attend remote medical training** — Advanced remote medical training available annually
+Brigade members complete eight different training modules, ensuring they are equipped and prepared to respond to the occasional incident. Training includes two online FEMA courses on incident management, 6-8 half-day in-person modules held largely on outer islands, and advanced remote medical training available annually.
 
 ---
 

--- a/src/pages/services/outer-island-brigades.mdx
+++ b/src/pages/services/outer-island-brigades.mdx
@@ -23,7 +23,7 @@ sidebar: >
 
 **The Outer Island Brigade Program brings emergency response capabilities to the remote islands in our district.** Community members receive training in basic firefighting, remote medical skills, and much more, enabling them to provide critical initial response while awaiting arrival of additional resources.
 
-<StyledImage src="/assets/media/brigade_rescue_training.jpg" alt="Brigade members receiving rescue training" align="center" />
+<StyledImage src="/assets/media/brigade_rescue_training.jpg" alt="Brigade members receiving patient movement training" align="center" />
 
 ## About the Program
 
@@ -31,20 +31,13 @@ San Juan Island Fire & Rescue's Outer Island Division works with community membe
 
 Since 2024, we've had over 100 community members sign up within the outer islands.
 
-<StyledImage src="/assets/media/brigade_utv_equipment.jpg" alt="Brigade members in wildland gear learning about UTV fire suppression equipment" size="large" align="center" />
+<StyledImage src="/assets/media/brigade_utv_equipment.jpg" alt="Brigade members learning to operate fire vehicles" size="large" align="center" />
 
 ---
 
 ## What Brigade Members Do
 
 Brigade members respond to local incidents and provide initial stabilization until additional resources arrive. Incidents include but are not limited to:
-
-* Medical incidents
-* Wildfires
-* Structure and vehicle fires
-* Boating accidents
-
-Depending on your interest and availability, you can participate in various ways:
 
 * **Fire Suppression** — Basic wildland firefighting techniques and equipment operation
 * **Medical Support** — First aid and initial medical care
@@ -60,7 +53,7 @@ Training sessions are scheduled throughout the spring and summer season, giving 
 
 Brigade members complete eight different training modules, ensuring they are equipped and prepared to respond to the occasional incident.
 
-**If you have interest in full brigade involvement:**
+**If you have interest in brigade involvement:**
 
 1. **Submit an application** — Once approved, you're covered under SJIF&R insurance for liability and injury
 2. **Complete online FEMA courses** — Two courses on incident management
@@ -71,11 +64,9 @@ Brigade members complete eight different training modules, ensuring they are equ
 
 ## Program Activities
 
-Beyond emergency response, our brigade program includes:
-
 * Training outer island community brigade responders and support members
-* Community fire extinguisher training and defensible space education at community gatherings
-* Work with WA State Parks to mitigate beach fires
+* Community fire extinguisher training and defensible space education
+* Working with WA State Parks to mitigate beach fires
 * Defensible space assessments through the [WA DNR Wildfire Ready Neighbors](/services/wildfire-ready/) program
 
 ---
@@ -85,8 +76,8 @@ Beyond emergency response, our brigade program includes:
 The process to join SJIF&R as a community brigade member is straightforward:
 
 1. **[Submit an application](https://forms.office.com/pages/responsepage.aspx?id=j4QiQRfDZ0KcB3xQQVDRva2d14yWAXNFl-Q6Prz2fIRUOFNSWEYyUEsxS0dFNVpITkdEWFg3RklHWCQlQCN0PWcu&route=shorturl)** — Complete the online form
-2. **Get approved** — Once approved, you're covered under SJIF&R insurance
-3. **Connect with your island coordinator** — Each island brigade has a coordinator as the primary point of contact
+2. Once approved, you're covered under SJIF&R insurance
+3. Each island brigade has a coordinator as the primary point of contact
 
 **Questions about the application process?** Contact Training Officer Karl Kuetzing at [kkuetzing@sjifire.org](mailto:kkuetzing@sjifire.org) or [360-378-5334](tel:360-378-5334).
 
@@ -102,6 +93,7 @@ The Outer Island Division provides coverage to multiple islands within San Juan 
 * Henry Island
 * Johns Island
 * Stuart Island
+* Pearl Island
 * Spieden Island
 
 Interested in starting a brigade on your island? [Contact us](/contact/) to discuss how we can work together.


### PR DESCRIPTION
## Summary
- Clarifies training includes remote medical skills and more
- Adds incident types list (medical, wildfires, structure/vehicle fires, boating accidents)
- Specifies spring/summer training schedule and mentions eight training modules
- Updates island list to current brigade locations (removes Crane, Decatur, Pearl, Waldron)
- Minor wording improvements throughout

## Test plan
- [ ] Preview page at /services/outer-island-brigades/
- [ ] Verify all content reads correctly
- [ ] Confirm island list is accurate