### PR TITLE
Update marine service image alt text for accuracy

### DIFF
--- a/src/pages/services/marine.mdx
+++ b/src/pages/services/marine.mdx
@@ -89,7 +89,7 @@ We use GAR (Green-Amber-Red) scoring to evaluate risk versus gain before accepti
 
 ## Service Area
 
-<StyledImage src="/assets/media/fireboat_wildland_transport.jpg" alt="Wildland firefighters preparing to board Fireboat 31" size="medium" align="right" />
+<StyledImage src="/assets/media/fireboat_wildland_transport.jpg" alt="Being dropped off at Lopez after a long day on Orcas Island" size="medium" align="right" />
 
 San Juan Island Fire & Rescue marine crew responds to threats to life, property, and the environment within our district and its waterways. Responses outside the district require fire chief authorization and appropriate interagency agreements.
 


### PR DESCRIPTION
## Summary
Updated the alt text for the fireboat image in the marine services page to provide a more accurate and descriptive caption of what the image depicts.

## Changes
- Modified the alt text for the fireboat image from "Wildland firefighters preparing to board Fireboat 31" to "Being dropped off at Lopez after a long day on Orcas Island"
- This change better reflects the actual content and context of the photograph

## Details
The alt text serves both accessibility and descriptive purposes. The updated text more accurately describes the scene captured in the image, improving the user experience for those relying on screen readers and providing better context for all visitors to the marine services page.

https://claude.ai/code/session_01APwcnpmJokRtDoiCkSfsPk