### PR TITLE
Add manual workflow dispatch trigger to Azure Static Web Apps

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -1,6 +1,8 @@
 name: Azure Static Web Apps CI/CD
 
 on:
+  # Manual trigger for ad-hoc deployments
+  workflow_dispatch:
   # Main branch: only deploy after CI passes
   workflow_run:
     workflows: ["CI"]
@@ -20,9 +22,11 @@ concurrency:
 
 jobs:
   build_and_deploy_job:
+    # For workflow_dispatch: always run (manual trigger)
     # For workflow_run (main): only if CI succeeded
     # For pull_request: always run (except on close)
     if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR adds the ability to manually trigger deployments to Azure Static Web Apps without waiting for CI to complete, while maintaining the existing automated deployment workflow.

## Changes
- Added `workflow_dispatch` trigger to enable manual ad-hoc deployments via GitHub Actions UI
- Updated the job condition to allow execution when manually triggered, in addition to the existing conditions for CI success and pull requests
- Added clarifying comments to document the three deployment scenarios

## Implementation Details
The `workflow_dispatch` event allows developers to manually trigger the deployment workflow from the GitHub Actions tab without requiring a push or pull request. The updated conditional logic ensures the job runs in three scenarios:
1. **Manual trigger** (`workflow_dispatch`): Always runs when manually invoked
2. **Main branch** (`workflow_run`): Only runs after CI workflow succeeds
3. **Pull requests** (`pull_request`): Always runs except when the PR is closed

This provides flexibility for emergency deployments or testing while preserving the safety checks for automated deployments.

https://claude.ai/code/session_01RUCdrX8xKUy7XK3Dn7psUH