### PR TITLE
Support top-level pages in navigation data generation

### DIFF
--- a/src/_data/nav.js
+++ b/src/_data/nav.js
@@ -42,14 +42,32 @@ function getPageInfo(url) {
 
   // Parse URL to get folder and slug (e.g., /about/join/ -> about, join)
   const parts = url.replace(/^\/|\/$/g, "").split("/");
-  if (parts.length < 2) return null;
+
+  const extensions = [".mdx", ".liquid", ".md"];
+
+  // Handle top-level pages (e.g., /join/)
+  if (parts.length === 1) {
+    const slug = parts[0];
+    for (const ext of extensions) {
+      const filePath = path.join(pagesDir, slug + ext);
+      if (fs.existsSync(filePath)) {
+        const content = fs.readFileSync(filePath, "utf8");
+        const { data } = matter(content);
+        return {
+          title: data.title,
+          nav_title: data.nav_title || data.title,
+          url: url,
+        };
+      }
+    }
+    return null;
+  }
 
   const folder = parts[0];
   const slug = parts[1];
   const folderPath = path.join(pagesDir, folder);
 
   // Find matching file
-  const extensions = [".mdx", ".liquid", ".md"];
   for (const ext of extensions) {
     const filePath = path.join(folderPath, slug + ext);
     if (fs.existsSync(filePath)) {


### PR DESCRIPTION
## Summary
Extended the navigation data generation to support top-level pages (e.g., `/join/`) in addition to nested pages (e.g., `/about/join/`). Previously, the function would return `null` for any URL with fewer than 2 path segments.

## Changes
- Added handling for single-segment URLs (top-level pages) that checks for matching files in the pages directory
- Moved the `extensions` array definition outside the conditional logic to avoid duplication
- Implemented the same file resolution logic for top-level pages as for nested pages, supporting `.mdx`, `.liquid`, and `.md` file formats
- Extracts title and nav_title from frontmatter for top-level pages, consistent with nested page behavior

## Implementation Details
The function now follows this logic:
1. Parse the URL into path segments
2. If only one segment exists (top-level page), search the pages directory directly for matching files
3. If two or more segments exist (nested page), search within the appropriate folder
4. For both cases, check for files with supported extensions and extract metadata from frontmatter

https://claude.ai/code/session_01N1zNSo2GZEAdxEbcbXeN9G