### PR TITLE
Fix TinaCMS admin CSP and add error diagnostics

### DIFF
--- a/api/src/functions/tina.js
+++ b/api/src/functions/tina.js
@@ -118,7 +118,7 @@ app.http("tina", {
           jsonBody: {
             error: "Internal server error",
             message: error.message,
-            stack: error.stack?.split('\n').slice(0, 5),
+            stack: error.stack?.split("\n").slice(0, 5),
           }
         };
       }

--- a/api/src/functions/tina.js
+++ b/api/src/functions/tina.js
@@ -77,9 +77,25 @@ app.http("tina", {
     context.log("TinaCMS request:", request.method, path);
 
     if (path === "health") {
+      // Check required environment variables (don't expose values, just presence)
+      const envCheck = {
+        GITHUB_APP_ID: !!process.env.GITHUB_APP_ID,
+        GITHUB_APP_PRIVATE_KEY: !!process.env.GITHUB_APP_PRIVATE_KEY,
+        GITHUB_APP_INSTALLATION_ID: !!process.env.GITHUB_APP_INSTALLATION_ID,
+        GITHUB_OWNER: !!process.env.GITHUB_OWNER,
+        GITHUB_REPO: !!process.env.GITHUB_REPO,
+        COSMOS_DB_CONNECTION_STRING: !!process.env.COSMOS_DB_CONNECTION_STRING,
+      };
+      const allConfigured = Object.values(envCheck).every(Boolean);
+
       return {
         status: 200,
-        jsonBody: { status: "ok", timestamp: new Date().toISOString(), isLocal },
+        jsonBody: {
+          status: allConfigured ? "ok" : "misconfigured",
+          timestamp: new Date().toISOString(),
+          isLocal,
+          envCheck,
+        },
       };
     }
 
@@ -96,7 +112,15 @@ app.http("tina", {
         return await handleTinaRequest(request, path);
       } catch (error) {
         context.error("TinaCMS error:", error.message, error.stack);
-        return { status: 500, jsonBody: { error: "Internal server error" } };
+        // Include error details for debugging (remove in production once stable)
+        return {
+          status: 500,
+          jsonBody: {
+            error: "Internal server error",
+            message: error.message,
+            stack: error.stack?.split('\n').slice(0, 5),
+          }
+        };
       }
     });
   },

--- a/api/tina/database.js
+++ b/api/tina/database.js
@@ -1,7 +1,7 @@
 import { createDatabase, createLocalDatabase, resolve as tinaResolve } from "@tinacms/datalayer";
-// mongodb-level is CommonJS, use default import
-import mongodbLevel from "mongodb-level";
-const { MongodbLevel } = mongodbLevel;
+// Handle both ESM default export and CommonJS module.exports
+import * as MongodbLevelModule from "mongodb-level";
+const MongodbLevel = MongodbLevelModule.MongodbLevel || MongodbLevelModule.default?.MongodbLevel;
 import { AuthoredGitHubProvider } from "../src/lib/git-provider.js";
 import { getGitHubToken, getGitHubConfig } from "../src/lib/github.js";
 

--- a/api/tina/database.js
+++ b/api/tina/database.js
@@ -1,5 +1,7 @@
 import { createDatabase, createLocalDatabase, resolve as tinaResolve } from "@tinacms/datalayer";
-import { MongodbLevel } from "mongodb-level";
+// mongodb-level is CommonJS, use default import
+import mongodbLevel from "mongodb-level";
+const { MongodbLevel } = mongodbLevel;
 import { AuthoredGitHubProvider } from "../src/lib/git-provider.js";
 import { getGitHubToken, getGitHubConfig } from "../src/lib/github.js";
 

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -119,7 +119,7 @@
     }
   },
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://res.cloudinary.com https://*.cloudinary.com; font-src 'self' data:; connect-src 'self' https://res.cloudinary.com https://api.cloudinary.com https://content.cloudinary.com; frame-src 'self' https://*.facebook.com https://*.facebook.net https://*.arcgis.com https://www.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://res.cloudinary.com https://*.cloudinary.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://res.cloudinary.com https://api.cloudinary.com https://content.cloudinary.com; frame-src 'self' https://*.facebook.com https://*.facebook.net https://*.arcgis.com https://www.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
     "X-XSS-Protection": "1; mode=block",

--- a/tina/database.ts
+++ b/tina/database.ts
@@ -1,6 +1,7 @@
 import { createDatabase, createLocalDatabase } from "@tinacms/datalayer";
-// @ts-ignore - no types for mongodb-level
-import { MongodbLevel } from "mongodb-level";
+// @ts-ignore - mongodb-level is CommonJS, use default import
+import mongodbLevel from "mongodb-level";
+const { MongodbLevel } = mongodbLevel;
 // @ts-ignore - no types for tinacms-gitprovider-github
 import { GitHubProvider } from "tinacms-gitprovider-github";
 

--- a/tina/database.ts
+++ b/tina/database.ts
@@ -1,7 +1,8 @@
 import { createDatabase, createLocalDatabase } from "@tinacms/datalayer";
-// @ts-ignore - mongodb-level is CommonJS, use default import
-import mongodbLevel from "mongodb-level";
-const { MongodbLevel } = mongodbLevel;
+// @ts-ignore - no types for mongodb-level
+import * as MongodbLevelModule from "mongodb-level";
+// Handle both ESM default export and CommonJS module.exports
+const MongodbLevel = (MongodbLevelModule as any).MongodbLevel || (MongodbLevelModule as any).default?.MongodbLevel;
 // @ts-ignore - no types for tinacms-gitprovider-github
 import { GitHubProvider } from "tinacms-gitprovider-github";
 


### PR DESCRIPTION
## Summary
- Add Google Fonts domains to CSP to fix blocked font loading in admin interface
- Add environment variable health check at `/api/tina/health`
- Include detailed error messages in 500 responses for debugging
- Fix CommonJS/ESM module interop issue with `mongodb-level` package

## Test plan
- [x] Deploy and verify `/api/tina/health` shows `envCheck` with all variables configured
- [x] Verify admin page loads fonts correctly (no CSP errors in console)
- [x] Verify TinaCMS admin interface works end-to-end

## Notes
Verbose error details are kept in production since:
1. The admin API endpoints are protected by Azure AD authentication
2. Azure Static Web Apps lacks built-in log streaming (requires Application Insights setup)