### PR TITLE
Correct Microsoft 365 acronym from M365 to MS365

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ GITHUB_BRANCH=main
 CLOUDINARY_API_KEY=
 CLOUDINARY_API_SECRET=
 
-# Microsoft Graph API (for personnel sync from M365)
+# Microsoft Graph API (for personnel sync from MS365)
 # Create an App Registration in Azure Portal > Microsoft Entra ID
 # Add API Permissions: Microsoft Graph > Application > User.Read.All, GroupMember.Read.All
 # Grant admin consent, then create a client secret

--- a/.github/workflows/sync-personnel.yml
+++ b/.github/workflows/sync-personnel.yml
@@ -1,4 +1,4 @@
-name: Sync Personnel from M365
+name: Sync Personnel from MS365
 
 on:
   schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Requires Node.js 20+. Output goes to `_site/`.
 - `src/pages/` - Content pages (`.liquid`/`.md`/`.mdx`) - URLs generated without `/pages/` prefix via `pages.11tydata.js`
 - `src/posts/` - News posts as JSON files (`YYYY-MM-DD-slug.json`)
 - `src/media_releases/` - Press release metadata (JSON) linking to PDFs in `src/assets/media_releases/`
-- `scripts/` - Standalone ESM scripts for data sync (NERIS, M365 personnel)
+- `scripts/` - Standalone ESM scripts for data sync (NERIS, MS365 personnel)
 - `api/` - Azure Functions backend (TypeScript) for GitHub content operations and auth
 
 ### Key Patterns

--- a/scripts/sync-personnel.mjs
+++ b/scripts/sync-personnel.mjs
@@ -481,7 +481,7 @@ async function main() {
           person.photo = photoUrl;
         } else {
           photoStats.skippedNoPhoto++;
-          console.log("    No photo in M365");
+          console.log("    No photo in MS365");
 
           // Keep existing photo if we have one
           if (photoExists) {
@@ -552,7 +552,7 @@ async function main() {
       console.log(`  - ${user.name} <${user.email}> (${user.jobTitle})`);
     }
     console.log("\nTo include these users, either:");
-    console.log("  1. Add them to a roleGroup in M365");
+    console.log("  1. Add them to a roleGroup in MS365");
     console.log("  2. Add their email to personnelSync.includeWithoutRole in site.json");
   }
 
@@ -561,7 +561,7 @@ async function main() {
     console.log(`  New photos downloaded: ${photoStats.downloaded}`);
     console.log(`  Photos updated (changed): ${photoStats.updated}`);
     console.log(`  Photos skipped (unchanged): ${photoStats.skippedUnchanged}`);
-    console.log(`  No photo in M365: ${photoStats.skippedNoPhoto}`);
+    console.log(`  No photo in MS365: ${photoStats.skippedNoPhoto}`);
   }
 
   console.log(`\nOutput written to ${OUTPUT_PATH}`);

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -448,7 +448,7 @@ export default defineConfig({
             create: false,
             delete: false,
           },
-          description: "Personnel list is automatically synced from Microsoft 365. To update staff or volunteer information, make changes in M365 and the website will update daily.",
+          description: "Personnel list is automatically synced from Microsoft 365. To update staff or volunteer information, make changes in MS365 and the website will update daily.",
         },
         fields: [
           {


### PR DESCRIPTION
## Summary
This PR corrects the acronym used throughout the codebase to refer to Microsoft 365, changing all instances of "M365" to the correct "MS365".

## Changes Made
- Updated `.env.example` comment for Microsoft Graph API configuration
- Updated GitHub Actions workflow name for personnel sync
- Updated documentation in `CLAUDE.md` describing script purposes
- Updated console log messages in `scripts/sync-personnel.mjs` for consistency
- Updated Tina CMS configuration description in `tina/config.ts`

## Details
The correct acronym for Microsoft 365 is "MS365", not "M365". This change ensures consistency across all user-facing documentation, comments, and log messages throughout the project. This improves clarity for developers and users who interact with these files and logs.

https://claude.ai/code/session_01PHsL3kCDm4x368tagKZ9Fi