### PR TITLE
Add sidebar blocks with fire insurance quick facts and WSRB lookup

### DIFF
--- a/src/pages/services/fire-insurance.mdx
+++ b/src/pages/services/fire-insurance.mdx
@@ -1,6 +1,23 @@
 ---
 title: "Fire Insurance Info"
 nav_order: 9
+sidebar_blocks:
+  - _template: richText
+    heading: "Quick Facts"
+    content: |
+      **Protection Class:** 6
+
+      **Rating Agency:** [WSRB](https://www1.wsrb.com/)
+
+      **Coverage Area:** San Juan Island, Brown, Henry, Johns, Pearl, Spieden, and Stuart Islands
+
+      Your property's protection class affects your homeowner's insurance premium.
+  - _template: button
+    heading: "Look Up Your Property"
+    description: "Find your property's exact protection class rating on the WSRB website."
+    button_text: "WSRB Property Lookup"
+    button_url: "https://www1.wsrb.com/protection-class-background"
+    new_tab: true
 ---
 
 ## District Fire Protection Overview


### PR DESCRIPTION
## Summary
Enhanced the Fire Insurance Info page with a new sidebar component containing quick reference information and a direct link to the WSRB property lookup tool.

## Changes
- Added `sidebar_blocks` frontmatter section to the fire insurance page
- Created a rich text block displaying quick facts including:
  - Protection Class rating (6)
  - Rating Agency (WSRB)
  - Coverage Area (San Juan Island and surrounding islands)
  - Explanatory note about protection class impact on premiums
- Added a button block linking to the WSRB Protection Class Background page for property lookup functionality
- Configured the button to open in a new tab for better UX

## Implementation Details
- Used the `richText` template for the informational sidebar block
- Used the `button` template for the call-to-action linking to external WSRB resource
- Maintained consistency with existing page structure and navigation order

https://claude.ai/code/session_01TbNYVqW6AYE2ApFExzzH1s