### PR TITLE
Use production URL for Cloudinary fetch

### DIFF
--- a/api/site-config.json
+++ b/api/site-config.json
@@ -1,5 +1,5 @@
 {
-  "cloudinaryFetchUrl": "https://jolly-moss-0db15021e.1.azurestaticapps.net",
+  "cloudinaryFetchUrl": "https://www.sjifire.org",
   "cloudinaryRootUrl": "https://res.cloudinary.com/san-juan-fire-district-3",
   "corsAllowedOrigins": [
     "https://www.sjifire.org",

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,7 +1,7 @@
 {
   "prodUrl": "https://www.sjifire.org",
   "publicDocumentsUrl": "https://sjifires.sharepoint.com/:f:/s/SJIFirePublicRecords/IgBbJPhsXp0iTLx2WataGf3dARGo93hz2540LD3Gmcu4LRk",
-  "cloudinaryFetchUrl": "https://jolly-moss-0db15021e.1.azurestaticapps.net",
+  "cloudinaryFetchUrl": "https://www.sjifire.org",
   "corsAllowedOrigins": [
     "https://www.sjifire.org",
     "https://sjifire.org",


### PR DESCRIPTION
## Summary
- Update `cloudinaryFetchUrl` from Azure staging URL to `https://www.sjifire.org`
- Prevents Cloudinary 404 errors when images aren't cached or staging cache expires
- Both `src/_data/site.json` and `api/site-config.json` updated for consistency

## Test plan
- [x] Verify Cloudinary fetch URLs in built pages use www.sjifire.org
- [x] Confirm images load correctly on staging deployment