### PR TITLE
Fix Our Team navigation by checking JSON config files

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -44,10 +44,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: '22'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: node-modules-cache
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Set Cloudinary fetch URL for staging

--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -57,10 +57,6 @@ jobs:
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Set Cloudinary fetch URL for staging
-        if: github.event_name == 'pull_request'
-        run: echo "CLOUDINARY_FETCH_URL=https://jolly-moss-0db15021e-${{ github.event.pull_request.number }}.westus2.1.azurestaticapps.net" >> $GITHUB_ENV
-
       - name: Build TinaCMS and index schema
         run: npx tinacms build --skip-cloud-checks
         env:

--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -57,6 +57,10 @@ jobs:
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 
+      - name: Set Cloudinary fetch URL for staging
+        if: github.event_name == 'pull_request'
+        run: echo "CLOUDINARY_FETCH_URL=https://jolly-moss-0db15021e-${{ github.event.pull_request.number }}.westus2.1.azurestaticapps.net" >> $GITHUB_ENV
+
       - name: Build TinaCMS and index schema
         run: npx tinacms build --skip-cloud-checks
         env:

--- a/src/_data/nav.js
+++ b/src/_data/nav.js
@@ -3,9 +3,21 @@ const path = require("path");
 const matter = require("gray-matter");
 
 const pagesDir = path.resolve(__dirname, "../pages");
+const dataDir = __dirname;
 const navigationJson = require("./navigation.json");
 const navigationConfig = navigationJson.items;
 const headerHighlightUrl = navigationJson.header_highlight_url;
+
+// Check for a corresponding JSON config file in _data/ (e.g., ourTeamPage.json for our-team.liquid)
+function getPageConfig(slug) {
+  // Convert slug to camelCase + "Page" (e.g., "our-team" -> "ourTeamPage")
+  const configName = slug.replace(/-([a-z])/g, (_, c) => c.toUpperCase()) + "Page";
+  const configPath = path.join(dataDir, configName + ".json");
+  if (fs.existsSync(configPath)) {
+    return require(configPath);
+  }
+  return null;
+}
 
 // Read all MDX/Liquid/MD pages and extract frontmatter
 function getPages(folder) {
@@ -24,12 +36,20 @@ function getPages(folder) {
       // Skip pages with permalink: false (content includes)
       if (data.permalink === false) return null;
 
+      // Check for JSON config file that overrides frontmatter
+      const config = getPageConfig(slug);
+      const title = config?.title || data.title;
+      const nav_title = config?.nav_title || data.nav_title || title;
+      const nav_order = config?.nav_order ?? data.nav_order ?? 999;
+      const nav_hidden = config?.nav_hidden ?? data.nav_hidden ?? false;
+
       return {
-        title: data.title,
-        nav_title: data.nav_title || data.title,
-        nav_order: data.nav_order ?? 999,
-        nav_hidden: data.nav_hidden ?? false,
+        title,
+        nav_title,
+        nav_order,
+        nav_hidden,
         url: `/${folder}/${slug}/`,
+        label: nav_title,
       };
     })
     .filter((page) => page && !page.nav_hidden)

--- a/src/pages/about/our-team.11tydata.js
+++ b/src/pages/about/our-team.11tydata.js
@@ -1,9 +1,9 @@
 // Pull page config from the editable JSON in _data/
-export default {
-  eleventyComputed: {
-    title: (data) => data.ourTeamPage?.title,
-    nav_order: (data) => data.ourTeamPage?.nav_order,
-    nav_title: (data) => data.ourTeamPage?.nav_title,
-    nav_hidden: (data) => data.ourTeamPage?.nav_hidden,
-  },
+const ourTeamPage = require("../../_data/ourTeamPage.json");
+
+module.exports = {
+  title: ourTeamPage.title,
+  nav_order: ourTeamPage.nav_order,
+  nav_title: ourTeamPage.nav_title,
+  nav_hidden: ourTeamPage.nav_hidden,
 };


### PR DESCRIPTION
## Summary

Fixes a bug where "Our Team" was missing from the About Us navigation dropdown, plus CI/CD improvements.

**Navigation fix:**
- `nav.js` reads frontmatter directly from page files using `gray-matter`
- `our-team.liquid` no longer has title/nav_order in frontmatter - they come from `ourTeamPage.json` via the `.11tydata.js` data cascade
- Updated `nav.js` to check for matching JSON config files in `_data/` when building navigation
- Pattern: `slug` → `slugPage.json` (e.g., `our-team` → `ourTeamPage.json`)

This ensures TinaCMS-edited navigation properties (title, nav_order, nav_title, nav_hidden) flow through to navigation correctly.

**CI/CD improvements:**
- Add `node_modules` caching to Azure deployment workflow (skips `npm ci` on cache hit)
- Bump Node.js 20 → 22 in Azure workflow to match CI

## Test plan
- [x] Build completes successfully
- [x] All 20 smoke tests pass
- [x] "Our Team" appears in About Us dropdown
- [x] Our Team page loads correctly