### PR TITLE
Fix volunteer count logic to include AO and Marine Crew roles

### DIFF
--- a/scripts/sync-personnel.mjs
+++ b/scripts/sync-personnel.mjs
@@ -344,31 +344,33 @@ function computeCounts(personnel) {
   const staff = personnel.filter(p => p.employee_type === "staff");
   const volunteers = personnel.filter(p => p.employee_type === "volunteer");
 
+  // Firefighter roles include operational certifications (AO, Marine) that indicate FF status
   const hasFirefighterRole = (p) =>
-    p.roles?.includes("Firefighter") || p.roles?.includes("Apparatus Operator");
+    p.roles?.includes("Firefighter") ||
+    p.roles?.includes("Wildland Firefighter") ||
+    p.roles?.includes("Apparatus Operator") ||
+    p.roles?.includes("Marine Crew");
 
-  // Full-time: FT Line Staff, Day Staff, or Administrative with FF/AO role
+  // Full-time: FT Line Staff, Day Staff, or Administrative with FF role
   const fullTimeTypes = ["FT Line Staff", "Day Staff", "Administrative"];
   const fullTimeFirefighters = staff.filter(
     p => fullTimeTypes.includes(p.staff_type) && hasFirefighterRole(p)
   ).length;
 
-  // Part-time: PT Line Staff with FF/AO role
+  // Part-time: PT Line Staff with FF role
   const partTimeFirefighters = staff.filter(
     p => p.staff_type === "PT Line Staff" && hasFirefighterRole(p)
   ).length;
 
-  // Administrative: staff without FF/AO role
+  // Administrative: staff without FF role
   const administrativeStaff = staff.filter(p => !hasFirefighterRole(p)).length;
 
-  // Volunteer firefighters: Firefighter or Wildland Firefighter role
-  const volunteerFirefighters = volunteers.filter(
-    p => p.roles?.includes("Firefighter") || p.roles?.includes("Wildland Firefighter")
-  ).length;
+  // Volunteer firefighters: any firefighter role
+  const volunteerFirefighters = volunteers.filter(p => hasFirefighterRole(p)).length;
 
   // Volunteer support: Support role but not a firefighter
   const volunteerSupport = volunteers.filter(
-    p => p.roles?.includes("Support") && !p.roles?.includes("Firefighter")
+    p => p.roles?.includes("Support") && !hasFirefighterRole(p)
   ).length;
 
   return {

--- a/src/_data/personnel.json
+++ b/src/_data/personnel.json
@@ -1,12 +1,12 @@
 {
-  "generated": "2026-01-30T16:08:26.643Z",
+  "generated": "2026-01-30T18:44:53.530Z",
   "count": 58,
   "counts": {
     "fullTimeFirefighters": 9,
     "partTimeFirefighters": 4,
     "administrativeStaff": 2,
-    "volunteerFirefighters": 31,
-    "volunteerSupport": 8
+    "volunteerFirefighters": 36,
+    "volunteerSupport": 7
   },
   "personnel": [
     {
@@ -204,7 +204,9 @@
       "title": null,
       "employee_type": "volunteer",
       "staff_type": "Volunteer",
-      "roles": [],
+      "roles": [
+        "Firefighter"
+      ],
       "photo": null
     },
     {


### PR DESCRIPTION
## Summary
- Personnel with Apparatus Operator or Marine Crew certifications are now counted as firefighters
- Previously, 4 volunteers were not being counted on the Key Information page
- Volunteer counts now match the Our Team page totals (43 volunteers)

## Changes
- Updated `hasFirefighterRole()` to include Wildland Firefighter, Apparatus Operator, and Marine Crew
- Use the helper consistently for both staff and volunteer counting
- Re-synced personnel.json with corrected counts

## Test plan
- [x] Verify Key Information page shows 36 volunteer FF + 7 volunteer support = 43 total
- [x] Verify Our Team page still shows 43 volunteers