### PR TITLE
Add weekly Cloudinary cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-cloudinary.yml
+++ b/.github/workflows/cleanup-cloudinary.yml
@@ -1,0 +1,58 @@
+name: Cleanup Cloudinary Assets
+
+on:
+  schedule:
+    # Run weekly on Sundays at 5 AM UTC (9 PM PST / 10 PM PDT Saturday)
+    - cron: '0 5 * * 0'
+  workflow_dispatch:
+    # Allow manual trigger from GitHub Actions UI
+    inputs:
+      dry_run:
+        description: 'Dry run (show what would be deleted without deleting)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      max_age_days:
+        description: 'Delete resources not accessed in N days'
+        required: false
+        default: '30'
+        type: string
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Cloudinary cleanup
+        env:
+          CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
+          CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
+        run: |
+          ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          if [ -n "${{ inputs.max_age_days }}" ] && [ "${{ inputs.max_age_days }}" != "30" ]; then
+            ARGS="$ARGS --days=${{ inputs.max_age_days }}"
+          fi
+          node scripts/cleanup-cloudinary.mjs $ARGS
+
+      - name: Summary
+        run: echo "Cloudinary cleanup completed. Check the logs above for details."

--- a/.github/workflows/cleanup-cloudinary.yml
+++ b/.github/workflows/cleanup-cloudinary.yml
@@ -21,6 +21,9 @@ on:
         default: '30'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tinacms/cli": "^2.1.0",
         "@tinacms/datalayer": "^2.0.6",
         "blockhash-core": "^0.1.0",
+        "cloudinary": "^2.9.0",
         "dotenv": "^17.2.3",
         "jpeg-js": "^0.4.4",
         "luxon": "^3.7.2",
@@ -1001,39 +1002,6 @@
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
         "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.978.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.978.0.tgz",
-      "integrity": "sha512-6SrS7Lpkllq19tpuBkSvUdeMLk4RwgU6OklcJ3NmCkIORhf/tFXTKRsSnm3XpZb7FgofCx69eOQUN/7r4xw8UQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.978.0",
-        "@aws-sdk/core": "^3.973.4",
-        "@aws-sdk/credential-provider-cognito-identity": "^3.972.2",
-        "@aws-sdk/credential-provider-env": "^3.972.2",
-        "@aws-sdk/credential-provider-http": "^3.972.4",
-        "@aws-sdk/credential-provider-ini": "^3.972.2",
-        "@aws-sdk/credential-provider-login": "^3.972.2",
-        "@aws-sdk/credential-provider-node": "^3.972.2",
-        "@aws-sdk/credential-provider-process": "^3.972.2",
-        "@aws-sdk/credential-provider-sso": "^3.972.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.2",
-        "@aws-sdk/nested-clients": "3.978.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9835,6 +9803,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.9.0.tgz",
+      "integrity": "sha512-F3iKMOy4y0zy0bi5JBp94SC7HY7i/ImfTPSUV07iJmRzH1Iz8WavFfOlJTR1zvYM/xKGoiGZ3my/zy64In0IQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -11764,6 +11744,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -23409,6 +23390,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
       "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -24416,6 +24398,7 @@
       "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
       "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "property-expr": "^2.0.5",
         "tiny-case": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tinacms/cli": "^2.1.0",
     "@tinacms/datalayer": "^2.0.6",
     "blockhash-core": "^0.1.0",
+    "cloudinary": "^2.9.0",
     "dotenv": "^17.2.3",
     "jpeg-js": "^0.4.4",
     "luxon": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "stats": "node src/scripts/generate-stats.mjs",
     "sync-personnel": "node scripts/sync-personnel.mjs",
+    "cleanup-cloudinary": "node scripts/cleanup-cloudinary.mjs",
     "dev": "eleventy --serve --port=8080",
     "build": "eleventy",
     "tina:dev": "TINA_PUBLIC_IS_LOCAL=true tinacms dev -c \"npm run dev\"",

--- a/scripts/cleanup-cloudinary.mjs
+++ b/scripts/cleanup-cloudinary.mjs
@@ -33,10 +33,10 @@ const require = createRequire(import.meta.url);
 const siteConfig = require("../api/site-config.json");
 
 // Extract cloud name from config
-const CLOUD_NAME = siteConfig.cloudinaryRootUrl.split("/").pop();
-const DEFAULT_MAX_AGE_DAYS = 30;
-const RESOURCE_TYPES = ["fetch", "upload"];
-const RATE_LIMIT_DELAY_MS = 200;
+export const CLOUD_NAME = siteConfig.cloudinaryRootUrl.split("/").pop();
+export const DEFAULT_MAX_AGE_DAYS = 30;
+export const RESOURCE_TYPES = ["fetch", "upload"];
+export const RATE_LIMIT_DELAY_MS = 200;
 
 function configure() {
   const apiKey = process.env.CLOUDINARY_API_KEY;
@@ -71,18 +71,18 @@ function getArgs() {
   return { dryRun: values["dry-run"], maxAgeDays };
 }
 
-function isOlderThan(dateString, maxAgeDays) {
+export function isOlderThan(dateString, maxAgeDays) {
   const date = new Date(dateString);
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - maxAgeDays);
   return date < cutoff;
 }
 
-function formatDate(dateString) {
+export function formatDate(dateString) {
   return new Date(dateString).toISOString().split("T")[0];
 }
 
-function formatBytes(bytes) {
+export function formatBytes(bytes) {
   if (bytes < 1024) return bytes + " B";
   if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
   return (bytes / (1024 * 1024)).toFixed(2) + " MB";
@@ -223,7 +223,11 @@ async function main() {
   console.log(`Space reclaimed: ${formatBytes(totalBytes)}`);
 }
 
-main().catch((err) => {
-  console.error("Error:", err.message);
-  process.exit(1);
-});
+// Run only when executed directly (not when imported for testing)
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    console.error("Error:", err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/cleanup-cloudinary.mjs
+++ b/scripts/cleanup-cloudinary.mjs
@@ -57,8 +57,8 @@ function parseArgs() {
       dryRun = true;
     } else if (arg.startsWith("--days=")) {
       maxAgeDays = parseInt(arg.split("=")[1], 10);
-      if (isNaN(maxAgeDays) || maxAgeDays < 1) {
-        throw new Error("--days must be a positive integer");
+      if (isNaN(maxAgeDays) || maxAgeDays < 0) {
+        throw new Error("--days must be a non-negative integer");
       }
     }
   }

--- a/scripts/cleanup-cloudinary.mjs
+++ b/scripts/cleanup-cloudinary.mjs
@@ -6,7 +6,7 @@
  * - Fetch resources: CDN-cached images from the site
  * - Upload resources: Temporary uploads from image optimization
  *
- * Uses the Cloudinary Admin API to list and delete stale resources.
+ * Uses the Cloudinary Node.js SDK.
  *
  * Usage:
  *   node scripts/cleanup-cloudinary.mjs [--dry-run] [--days=30]
@@ -24,8 +24,10 @@
  */
 
 import "dotenv/config";
-import { createRequire } from "node:module";
+import { parseArgs } from "node:util";
 import { setTimeout } from "node:timers/promises";
+import { createRequire } from "node:module";
+import { v2 as cloudinary } from "cloudinary";
 
 const require = createRequire(import.meta.url);
 const siteConfig = require("../api/site-config.json");
@@ -33,8 +35,10 @@ const siteConfig = require("../api/site-config.json");
 // Extract cloud name from config
 const CLOUD_NAME = siteConfig.cloudinaryRootUrl.split("/").pop();
 const DEFAULT_MAX_AGE_DAYS = 30;
+const RESOURCE_TYPES = ["fetch", "upload"];
+const RATE_LIMIT_DELAY_MS = 200;
 
-function getConfig() {
+function configure() {
   const apiKey = process.env.CLOUDINARY_API_KEY;
   const apiSecret = process.env.CLOUDINARY_API_SECRET;
 
@@ -44,80 +48,27 @@ function getConfig() {
     );
   }
 
-  return { apiKey, apiSecret, cloudName: CLOUD_NAME };
+  cloudinary.config({
+    cloud_name: CLOUD_NAME,
+    api_key: apiKey,
+    api_secret: apiSecret,
+  });
 }
 
-function parseArgs() {
-  const args = process.argv.slice(2);
-  let dryRun = false;
-  let maxAgeDays = DEFAULT_MAX_AGE_DAYS;
-
-  for (const arg of args) {
-    if (arg === "--dry-run") {
-      dryRun = true;
-    } else if (arg.startsWith("--days=")) {
-      maxAgeDays = parseInt(arg.split("=")[1], 10);
-      if (isNaN(maxAgeDays) || maxAgeDays < 0) {
-        throw new Error("--days must be a non-negative integer");
-      }
-    }
-  }
-
-  return { dryRun, maxAgeDays };
-}
-
-async function cloudinaryRequest(config, endpoint, method = "GET", body = null) {
-  const auth = Buffer.from(`${config.apiKey}:${config.apiSecret}`).toString("base64");
-  const url = `https://api.cloudinary.com/v1_1/${config.cloudName}${endpoint}`;
-
-  const options = {
-    method,
-    headers: {
-      Authorization: `Basic ${auth}`,
-      "Content-Type": "application/json",
+function getArgs() {
+  const { values } = parseArgs({
+    options: {
+      "dry-run": { type: "boolean", default: false },
+      days: { type: "string", default: String(DEFAULT_MAX_AGE_DAYS) },
     },
-  };
-
-  if (body) {
-    options.body = JSON.stringify(body);
-  }
-
-  const response = await fetch(url, options);
-
-  if (!response.ok) {
-    const error = await response.text();
-    throw new Error(`Cloudinary API error (${response.status}): ${error}`);
-  }
-
-  return response.json();
-}
-
-// Resource types to clean up
-const RESOURCE_TYPES = ["fetch", "upload"];
-
-async function listResources(config, type, nextCursor = null) {
-  let endpoint = `/resources/image/${type}?max_results=500`;
-  if (nextCursor) {
-    endpoint += `&next_cursor=${encodeURIComponent(nextCursor)}`;
-  }
-
-  return cloudinaryRequest(config, endpoint);
-}
-
-async function deleteResource(config, publicId, type) {
-  // Delete a specific resource by public_id and type
-  return cloudinaryRequest(config, `/resources/image/${type}`, "DELETE", {
-    public_ids: [publicId],
   });
-}
 
-async function deleteDerivedResources(config, derivedIds) {
-  // Delete derived resources by their IDs
-  if (derivedIds.length === 0) return { deleted: {} };
+  const maxAgeDays = parseInt(values.days, 10);
+  if (isNaN(maxAgeDays) || maxAgeDays < 0) {
+    throw new Error("--days must be a non-negative integer");
+  }
 
-  return cloudinaryRequest(config, "/derived_resources", "DELETE", {
-    derived_resource_ids: derivedIds,
-  });
+  return { dryRun: values["dry-run"], maxAgeDays };
 }
 
 function isOlderThan(dateString, maxAgeDays) {
@@ -137,12 +88,26 @@ function formatBytes(bytes) {
   return (bytes / (1024 * 1024)).toFixed(2) + " MB";
 }
 
-// Rate limiting for free plan API limits
-const RATE_LIMIT_DELAY_MS = 200;
+async function listResources(type, nextCursor = null) {
+  const options = { type, max_results: 500, resource_type: "image" };
+  if (nextCursor) {
+    options.next_cursor = nextCursor;
+  }
+  return cloudinary.api.resources(options);
+}
+
+async function deleteResources(publicIds, type) {
+  return cloudinary.api.delete_resources(publicIds, { type, resource_type: "image" });
+}
+
+async function deleteDerivedResources(derivedIds) {
+  if (derivedIds.length === 0) return { deleted: {} };
+  return cloudinary.api.delete_derived_resources(derivedIds);
+}
 
 async function main() {
-  const { dryRun, maxAgeDays } = parseArgs();
-  const config = getConfig();
+  const { dryRun, maxAgeDays } = getArgs();
+  configure();
 
   console.log(`Cloudinary Cleanup - ${CLOUD_NAME}`);
   console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE"}`);
@@ -164,7 +129,7 @@ async function main() {
     console.log(`\n[${resourceType.toUpperCase()}] Scanning...`);
 
     do {
-      const result = await listResources(config, resourceType, nextCursor);
+      const result = await listResources(resourceType, nextCursor);
       const resources = result.resources || [];
       nextCursor = result.next_cursor;
 
@@ -178,8 +143,6 @@ async function main() {
 
       for (const resource of resources) {
         // Use created_at as proxy for last access if last_access not available
-        // Cloudinary's fetch resources are recreated on access, so created_at
-        // effectively represents last access for fetch-type resources
         const lastAccess = resource.last_access || resource.created_at;
 
         if (isOlderThan(lastAccess, maxAgeDays)) {
@@ -230,12 +193,12 @@ async function main() {
     try {
       // First delete derived resources if any
       if (item.derivedIds.length > 0) {
-        await deleteDerivedResources(config, item.derivedIds);
+        await deleteDerivedResources(item.derivedIds);
         await setTimeout(RATE_LIMIT_DELAY_MS);
       }
 
-      // Then delete the main resource
-      await deleteResource(config, item.publicId, item.type);
+      // Delete the main resource
+      await deleteResources([item.publicId], item.type);
       deletedCount++;
 
       // Rate limit to stay within free plan API limits
@@ -247,7 +210,7 @@ async function main() {
     } catch (error) {
       console.error(`  Failed to delete ${item.publicId}: ${error.message}`);
       // On rate limit errors, wait longer before continuing
-      if (error.message.includes("420") || error.message.includes("rate")) {
+      if (error.message.includes("420") || error.message.includes("Rate")) {
         console.log("  Rate limited, waiting 60 seconds...");
         await setTimeout(60000);
       }

--- a/scripts/cleanup-cloudinary.mjs
+++ b/scripts/cleanup-cloudinary.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 /**
- * Clean up old Cloudinary fetched assets
+ * Clean up old Cloudinary assets
  *
- * Removes derived/fetched resources that haven't been accessed in 30 days.
+ * Removes resources that haven't been accessed in 30 days:
+ * - Fetch resources: CDN-cached images from the site
+ * - Upload resources: Temporary uploads from image optimization
+ *
  * Uses the Cloudinary Admin API to list and delete stale resources.
  *
  * Usage:
@@ -89,9 +92,11 @@ async function cloudinaryRequest(config, endpoint, method = "GET", body = null) 
   return response.json();
 }
 
-async function listFetchedResources(config, nextCursor = null) {
-  // List resources of type "fetch" which are the cached CDN resources
-  let endpoint = "/resources/image/fetch?max_results=500";
+// Resource types to clean up
+const RESOURCE_TYPES = ["fetch", "upload"];
+
+async function listResources(config, type, nextCursor = null) {
+  let endpoint = `/resources/image/${type}?max_results=500`;
   if (nextCursor) {
     endpoint += `&next_cursor=${encodeURIComponent(nextCursor)}`;
   }
@@ -99,11 +104,10 @@ async function listFetchedResources(config, nextCursor = null) {
   return cloudinaryRequest(config, endpoint);
 }
 
-async function deleteResource(config, publicId) {
-  // Delete a specific resource by public_id
-  return cloudinaryRequest(config, "/resources/image/upload", "DELETE", {
+async function deleteResource(config, publicId, type) {
+  // Delete a specific resource by public_id and type
+  return cloudinaryRequest(config, `/resources/image/${type}`, "DELETE", {
     public_ids: [publicId],
-    type: "fetch",
   });
 }
 
@@ -143,49 +147,57 @@ async function main() {
   console.log(`Cloudinary Cleanup - ${CLOUD_NAME}`);
   console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE"}`);
   console.log(`Max age: ${maxAgeDays} days`);
+  console.log(`Resource types: ${RESOURCE_TYPES.join(", ")}`);
   console.log("=".repeat(50));
 
   let totalResources = 0;
   let staleResources = 0;
   let totalBytes = 0;
   let deletedCount = 0;
-  let nextCursor = null;
   const staleList = [];
 
-  // Iterate through all fetched resources
-  do {
-    console.log(`\nFetching resources${nextCursor ? " (next page)" : ""}...`);
+  // Iterate through all resource types
+  for (const resourceType of RESOURCE_TYPES) {
+    let nextCursor = null;
+    let typeCount = 0;
 
-    const result = await listFetchedResources(config, nextCursor);
-    const resources = result.resources || [];
-    nextCursor = result.next_cursor;
+    console.log(`\n[${resourceType.toUpperCase()}] Scanning...`);
 
-    totalResources += resources.length;
-    console.log(`Found ${resources.length} resources in this batch`);
+    do {
+      const result = await listResources(config, resourceType, nextCursor);
+      const resources = result.resources || [];
+      nextCursor = result.next_cursor;
 
-    // Rate limit between pagination requests
-    if (nextCursor) {
-      await setTimeout(RATE_LIMIT_DELAY_MS);
-    }
+      typeCount += resources.length;
+      totalResources += resources.length;
 
-    for (const resource of resources) {
-      // Use created_at as proxy for last access if last_access not available
-      // Cloudinary's fetch resources are recreated on access, so created_at
-      // effectively represents last access for fetch-type resources
-      const lastAccess = resource.last_access || resource.created_at;
-
-      if (isOlderThan(lastAccess, maxAgeDays)) {
-        staleResources++;
-        totalBytes += resource.bytes || 0;
-        staleList.push({
-          publicId: resource.public_id,
-          lastAccess: formatDate(lastAccess),
-          bytes: resource.bytes || 0,
-          derivedIds: (resource.derived || []).map((d) => d.id),
-        });
+      // Rate limit between pagination requests
+      if (nextCursor) {
+        await setTimeout(RATE_LIMIT_DELAY_MS);
       }
-    }
-  } while (nextCursor);
+
+      for (const resource of resources) {
+        // Use created_at as proxy for last access if last_access not available
+        // Cloudinary's fetch resources are recreated on access, so created_at
+        // effectively represents last access for fetch-type resources
+        const lastAccess = resource.last_access || resource.created_at;
+
+        if (isOlderThan(lastAccess, maxAgeDays)) {
+          staleResources++;
+          totalBytes += resource.bytes || 0;
+          staleList.push({
+            publicId: resource.public_id,
+            type: resourceType,
+            lastAccess: formatDate(lastAccess),
+            bytes: resource.bytes || 0,
+            derivedIds: (resource.derived || []).map((d) => d.id),
+          });
+        }
+      }
+    } while (nextCursor);
+
+    console.log(`  Found ${typeCount} resources`);
+  }
 
   console.log("\n" + "=".repeat(50));
   console.log(`Total resources scanned: ${totalResources}`);
@@ -223,7 +235,7 @@ async function main() {
       }
 
       // Then delete the main resource
-      await deleteResource(config, item.publicId);
+      await deleteResource(config, item.publicId, item.type);
       deletedCount++;
 
       // Rate limit to stay within free plan API limits

--- a/scripts/cleanup-cloudinary.mjs
+++ b/scripts/cleanup-cloudinary.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * Clean up old Cloudinary fetched assets
+ *
+ * Removes derived/fetched resources that haven't been accessed in 30 days.
+ * Uses the Cloudinary Admin API to list and delete stale resources.
+ *
+ * Usage:
+ *   node scripts/cleanup-cloudinary.mjs [--dry-run] [--days=30]
+ *
+ * Options:
+ *   --dry-run   Show what would be deleted without actually deleting
+ *   --days=N    Delete resources not accessed in N days (default: 30)
+ *
+ * Required environment variables:
+ *   CLOUDINARY_API_KEY
+ *   CLOUDINARY_API_SECRET
+ *
+ * Note: This script is designed to work within Cloudinary's free plan API limits.
+ * It uses conservative rate limiting between API calls.
+ */
+
+import "dotenv/config";
+import { createRequire } from "node:module";
+import { setTimeout } from "node:timers/promises";
+
+const require = createRequire(import.meta.url);
+const siteConfig = require("../api/site-config.json");
+
+// Extract cloud name from config
+const CLOUD_NAME = siteConfig.cloudinaryRootUrl.split("/").pop();
+const DEFAULT_MAX_AGE_DAYS = 30;
+
+function getConfig() {
+  const apiKey = process.env.CLOUDINARY_API_KEY;
+  const apiSecret = process.env.CLOUDINARY_API_SECRET;
+
+  if (!apiKey || !apiSecret) {
+    throw new Error(
+      "Missing CLOUDINARY_API_KEY or CLOUDINARY_API_SECRET environment variables"
+    );
+  }
+
+  return { apiKey, apiSecret, cloudName: CLOUD_NAME };
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let dryRun = false;
+  let maxAgeDays = DEFAULT_MAX_AGE_DAYS;
+
+  for (const arg of args) {
+    if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg.startsWith("--days=")) {
+      maxAgeDays = parseInt(arg.split("=")[1], 10);
+      if (isNaN(maxAgeDays) || maxAgeDays < 1) {
+        throw new Error("--days must be a positive integer");
+      }
+    }
+  }
+
+  return { dryRun, maxAgeDays };
+}
+
+async function cloudinaryRequest(config, endpoint, method = "GET", body = null) {
+  const auth = Buffer.from(`${config.apiKey}:${config.apiSecret}`).toString("base64");
+  const url = `https://api.cloudinary.com/v1_1/${config.cloudName}${endpoint}`;
+
+  const options = {
+    method,
+    headers: {
+      Authorization: `Basic ${auth}`,
+      "Content-Type": "application/json",
+    },
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, options);
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Cloudinary API error (${response.status}): ${error}`);
+  }
+
+  return response.json();
+}
+
+async function listFetchedResources(config, nextCursor = null) {
+  // List resources of type "fetch" which are the cached CDN resources
+  let endpoint = "/resources/image/fetch?max_results=500";
+  if (nextCursor) {
+    endpoint += `&next_cursor=${encodeURIComponent(nextCursor)}`;
+  }
+
+  return cloudinaryRequest(config, endpoint);
+}
+
+async function deleteResource(config, publicId) {
+  // Delete a specific resource by public_id
+  return cloudinaryRequest(config, "/resources/image/upload", "DELETE", {
+    public_ids: [publicId],
+    type: "fetch",
+  });
+}
+
+async function deleteDerivedResources(config, derivedIds) {
+  // Delete derived resources by their IDs
+  if (derivedIds.length === 0) return { deleted: {} };
+
+  return cloudinaryRequest(config, "/derived_resources", "DELETE", {
+    derived_resource_ids: derivedIds,
+  });
+}
+
+function isOlderThan(dateString, maxAgeDays) {
+  const date = new Date(dateString);
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - maxAgeDays);
+  return date < cutoff;
+}
+
+function formatDate(dateString) {
+  return new Date(dateString).toISOString().split("T")[0];
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return bytes + " B";
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+  return (bytes / (1024 * 1024)).toFixed(2) + " MB";
+}
+
+// Rate limiting for free plan API limits
+const RATE_LIMIT_DELAY_MS = 200;
+
+async function main() {
+  const { dryRun, maxAgeDays } = parseArgs();
+  const config = getConfig();
+
+  console.log(`Cloudinary Cleanup - ${CLOUD_NAME}`);
+  console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE"}`);
+  console.log(`Max age: ${maxAgeDays} days`);
+  console.log("=".repeat(50));
+
+  let totalResources = 0;
+  let staleResources = 0;
+  let totalBytes = 0;
+  let deletedCount = 0;
+  let nextCursor = null;
+  const staleList = [];
+
+  // Iterate through all fetched resources
+  do {
+    console.log(`\nFetching resources${nextCursor ? " (next page)" : ""}...`);
+
+    const result = await listFetchedResources(config, nextCursor);
+    const resources = result.resources || [];
+    nextCursor = result.next_cursor;
+
+    totalResources += resources.length;
+    console.log(`Found ${resources.length} resources in this batch`);
+
+    // Rate limit between pagination requests
+    if (nextCursor) {
+      await setTimeout(RATE_LIMIT_DELAY_MS);
+    }
+
+    for (const resource of resources) {
+      // Use created_at as proxy for last access if last_access not available
+      // Cloudinary's fetch resources are recreated on access, so created_at
+      // effectively represents last access for fetch-type resources
+      const lastAccess = resource.last_access || resource.created_at;
+
+      if (isOlderThan(lastAccess, maxAgeDays)) {
+        staleResources++;
+        totalBytes += resource.bytes || 0;
+        staleList.push({
+          publicId: resource.public_id,
+          lastAccess: formatDate(lastAccess),
+          bytes: resource.bytes || 0,
+          derivedIds: (resource.derived || []).map((d) => d.id),
+        });
+      }
+    }
+  } while (nextCursor);
+
+  console.log("\n" + "=".repeat(50));
+  console.log(`Total resources scanned: ${totalResources}`);
+  console.log(`Stale resources (>${maxAgeDays} days): ${staleResources}`);
+  console.log(`Total space to reclaim: ${formatBytes(totalBytes)}`);
+
+  if (staleList.length === 0) {
+    console.log("\nNo stale resources to clean up.");
+    return;
+  }
+
+  console.log("\nStale resources:");
+  for (const item of staleList.slice(0, 20)) {
+    console.log(`  - ${item.publicId}`);
+    console.log(`    Last access: ${item.lastAccess}, Size: ${formatBytes(item.bytes)}`);
+  }
+  if (staleList.length > 20) {
+    console.log(`  ... and ${staleList.length - 20} more`);
+  }
+
+  if (dryRun) {
+    console.log("\n[DRY RUN] No resources were deleted.");
+    return;
+  }
+
+  // Delete stale resources
+  console.log("\nDeleting stale resources...");
+
+  for (const item of staleList) {
+    try {
+      // First delete derived resources if any
+      if (item.derivedIds.length > 0) {
+        await deleteDerivedResources(config, item.derivedIds);
+        await setTimeout(RATE_LIMIT_DELAY_MS);
+      }
+
+      // Then delete the main resource
+      await deleteResource(config, item.publicId);
+      deletedCount++;
+
+      // Rate limit to stay within free plan API limits
+      await setTimeout(RATE_LIMIT_DELAY_MS);
+
+      if (deletedCount % 10 === 0) {
+        console.log(`  Deleted ${deletedCount}/${staleList.length}...`);
+      }
+    } catch (error) {
+      console.error(`  Failed to delete ${item.publicId}: ${error.message}`);
+      // On rate limit errors, wait longer before continuing
+      if (error.message.includes("420") || error.message.includes("rate")) {
+        console.log("  Rate limited, waiting 60 seconds...");
+        await setTimeout(60000);
+      }
+    }
+  }
+
+  console.log("\n" + "=".repeat(50));
+  console.log("Cleanup complete!");
+  console.log(`Deleted: ${deletedCount} resources`);
+  console.log(`Space reclaimed: ${formatBytes(totalBytes)}`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err.message);
+  process.exit(1);
+});

--- a/tests/cleanup-cloudinary.test.mjs
+++ b/tests/cleanup-cloudinary.test.mjs
@@ -1,0 +1,138 @@
+import { describe, it, mock, beforeEach } from "node:test";
+import assert from "node:assert";
+
+import {
+  CLOUD_NAME,
+  DEFAULT_MAX_AGE_DAYS,
+  RESOURCE_TYPES,
+  RATE_LIMIT_DELAY_MS,
+  isOlderThan,
+  formatDate,
+  formatBytes,
+} from "../scripts/cleanup-cloudinary.mjs";
+
+describe("cleanup-cloudinary module", () => {
+  describe("constants", () => {
+    it("CLOUD_NAME is extracted from site config", () => {
+      assert.strictEqual(CLOUD_NAME, "san-juan-fire-district-3");
+    });
+
+    it("DEFAULT_MAX_AGE_DAYS is 30", () => {
+      assert.strictEqual(DEFAULT_MAX_AGE_DAYS, 30);
+    });
+
+    it("RESOURCE_TYPES includes fetch and upload", () => {
+      assert.deepStrictEqual(RESOURCE_TYPES, ["fetch", "upload"]);
+    });
+
+    it("RATE_LIMIT_DELAY_MS is 200ms", () => {
+      assert.strictEqual(RATE_LIMIT_DELAY_MS, 200);
+    });
+  });
+
+  describe("isOlderThan", () => {
+    it("returns true for dates older than maxAgeDays", () => {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 10);
+      assert.strictEqual(isOlderThan(oldDate.toISOString(), 5), true);
+    });
+
+    it("returns false for dates newer than maxAgeDays", () => {
+      const recentDate = new Date();
+      recentDate.setDate(recentDate.getDate() - 2);
+      assert.strictEqual(isOlderThan(recentDate.toISOString(), 5), false);
+    });
+
+    it("returns false for today with maxAgeDays=1", () => {
+      const today = new Date();
+      assert.strictEqual(isOlderThan(today.toISOString(), 1), false);
+    });
+
+    it("returns true for all dates when maxAgeDays=0", () => {
+      const now = new Date();
+      // Even dates from a millisecond ago are "older than 0 days"
+      const slightlyOld = new Date(now.getTime() - 1);
+      assert.strictEqual(isOlderThan(slightlyOld.toISOString(), 0), true);
+    });
+
+    it("handles date strings in various formats", () => {
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 35);
+
+      // ISO format
+      assert.strictEqual(isOlderThan(thirtyDaysAgo.toISOString(), 30), true);
+
+      // Date-only string
+      const dateOnly = thirtyDaysAgo.toISOString().split("T")[0];
+      assert.strictEqual(isOlderThan(dateOnly, 30), true);
+    });
+
+    it("returns true for exactly maxAgeDays boundary", () => {
+      const exactBoundary = new Date();
+      exactBoundary.setDate(exactBoundary.getDate() - 5);
+      exactBoundary.setHours(0, 0, 0, 0);
+
+      // At or before the cutoff should be considered stale
+      assert.strictEqual(isOlderThan(exactBoundary.toISOString(), 5), true);
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats ISO date string to YYYY-MM-DD", () => {
+      assert.strictEqual(formatDate("2026-01-15T10:30:00.000Z"), "2026-01-15");
+    });
+
+    it("handles date without time component", () => {
+      assert.strictEqual(formatDate("2026-06-20"), "2026-06-20");
+    });
+
+    it("handles Date object converted to string", () => {
+      const date = new Date("2026-03-25T15:45:00Z");
+      assert.strictEqual(formatDate(date.toISOString()), "2026-03-25");
+    });
+
+    it("pads single-digit months and days", () => {
+      assert.strictEqual(formatDate("2026-01-05T00:00:00Z"), "2026-01-05");
+    });
+  });
+
+  describe("formatBytes", () => {
+    it("formats bytes under 1KB", () => {
+      assert.strictEqual(formatBytes(0), "0 B");
+      assert.strictEqual(formatBytes(100), "100 B");
+      assert.strictEqual(formatBytes(1023), "1023 B");
+    });
+
+    it("formats bytes as KB", () => {
+      assert.strictEqual(formatBytes(1024), "1.0 KB");
+      assert.strictEqual(formatBytes(1536), "1.5 KB");
+      assert.strictEqual(formatBytes(10240), "10.0 KB");
+      assert.strictEqual(formatBytes(512000), "500.0 KB");
+    });
+
+    it("formats bytes as MB", () => {
+      assert.strictEqual(formatBytes(1024 * 1024), "1.00 MB");
+      assert.strictEqual(formatBytes(1.5 * 1024 * 1024), "1.50 MB");
+      assert.strictEqual(formatBytes(10 * 1024 * 1024), "10.00 MB");
+      assert.strictEqual(formatBytes(123.45 * 1024 * 1024), "123.45 MB");
+    });
+
+    it("handles boundary values correctly", () => {
+      // Just under 1KB
+      assert.strictEqual(formatBytes(1023), "1023 B");
+      // Exactly 1KB
+      assert.strictEqual(formatBytes(1024), "1.0 KB");
+      // Just under 1MB
+      assert.strictEqual(formatBytes(1024 * 1024 - 1), "1024.0 KB");
+      // Exactly 1MB
+      assert.strictEqual(formatBytes(1024 * 1024), "1.00 MB");
+    });
+
+    it("handles large values", () => {
+      // 1GB
+      assert.strictEqual(formatBytes(1024 * 1024 * 1024), "1024.00 MB");
+      // 500MB
+      assert.strictEqual(formatBytes(500 * 1024 * 1024), "500.00 MB");
+    });
+  });
+});

--- a/tests/cleanup-cloudinary.test.mjs
+++ b/tests/cleanup-cloudinary.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, mock, beforeEach } from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert";
 
 import {


### PR DESCRIPTION
## Summary
- Add automated cleanup of stale Cloudinary fetched assets
- Removes resources not accessed in 30 days to prevent accumulation on free plan
- Includes rate limiting to stay within API limits

## Changes
- `scripts/cleanup-cloudinary.mjs` - Cleanup script using Cloudinary Admin API
- `.github/workflows/cleanup-cloudinary.yml` - Weekly workflow (Sundays 5 AM UTC)
- `package.json` - Add `cleanup-cloudinary` npm script

## Features
- `--dry-run` flag to preview without deleting
- `--days=N` to customize max age (default 30)
- Manual trigger via GitHub Actions UI
- Rate limiting for free plan compatibility

## Test plan
- [x] Run manually with `--dry-run` to verify API access
- [x] Trigger workflow manually from Actions tab with dry_run=true