### PR TITLE
Use Azure Key Vault with OIDC for GitHub Actions

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -41,6 +41,22 @@ jobs:
           submodules: true
           fetch-depth: 1
 
+      - name: Azure login with OIDC
+        uses: azure/login@v2
+        with:
+          client-id: 7d94bc11-9bdf-445b-96c8-fca2560cd441
+          tenant-id: 4122848f-c317-4267-9c07-7c504150d1bd
+          allow-no-subscriptions: true
+
+      - name: Get secrets from Key Vault
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            echo "COSMOS_DB_CONNECTION_STRING=$(az keyvault secret show --vault-name gh-website-utilities --name COSMOS-DB-CONNECTION-STRING --query value -o tsv)" >> $GITHUB_ENV
+            echo "COSMOS_DB_NAME=$(az keyvault secret show --vault-name gh-website-utilities --name COSMOS-DB-NAME --query value -o tsv)" >> $GITHUB_ENV
+            echo "AZURE_STATIC_WEB_APPS_API_TOKEN=$(az keyvault secret show --vault-name gh-website-utilities --name AZURE-STATIC-WEB-APPS-API-TOKEN --query value -o tsv)" >> $GITHUB_ENV
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -67,8 +83,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
-          COSMOS_DB_CONNECTION_STRING: ${{ secrets.COSMOS_DB_CONNECTION_STRING }}
-          COSMOS_DB_NAME: ${{ secrets.COSMOS_DB_NAME }}
 
       - name: Build 11ty site
         run: npm run build
@@ -90,7 +104,7 @@ jobs:
         continue-on-error: true
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_JOLLY_MOSS_0DB15021E }}
+          azure_static_web_apps_api_token: ${{ env.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
           app_location: "_site"
@@ -102,8 +116,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
-          COSMOS_DB_CONNECTION_STRING: ${{ secrets.COSMOS_DB_CONNECTION_STRING }}
-          COSMOS_DB_NAME: ${{ secrets.COSMOS_DB_NAME }}
           TINA_PUBLIC_IS_LOCAL: "false"
 
       - name: Wait before retry
@@ -115,7 +127,7 @@ jobs:
         if: steps.builddeploy.outcome == 'failure'
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_JOLLY_MOSS_0DB15021E }}
+          azure_static_web_apps_api_token: ${{ env.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
           app_location: "_site"
@@ -127,8 +139,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
-          COSMOS_DB_CONNECTION_STRING: ${{ secrets.COSMOS_DB_CONNECTION_STRING }}
-          COSMOS_DB_NAME: ${{ secrets.COSMOS_DB_NAME }}
           TINA_PUBLIC_IS_LOCAL: "false"
 
   close_pull_request_job:
@@ -140,6 +150,20 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Azure login with OIDC
+        uses: azure/login@v2
+        with:
+          client-id: 7d94bc11-9bdf-445b-96c8-fca2560cd441
+          tenant-id: 4122848f-c317-4267-9c07-7c504150d1bd
+          allow-no-subscriptions: true
+
+      - name: Get secrets from Key Vault
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            echo "AZURE_STATIC_WEB_APPS_API_TOKEN=$(az keyvault secret show --vault-name gh-website-utilities --name AZURE-STATIC-WEB-APPS-API-TOKEN --query value -o tsv)" >> $GITHUB_ENV
+
       - name: Install OIDC Client from Core Package
         run: npm install @actions/core@1.6.0 @actions/http-client
 
@@ -156,7 +180,7 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_JOLLY_MOSS_0DB15021E }}
+          azure_static_web_apps_api_token: ${{ env.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "close"
           github_id_token: ${{ steps.idtoken.outputs.result }}

--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -53,9 +53,17 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            echo "COSMOS_DB_CONNECTION_STRING=$(az keyvault secret show --vault-name gh-website-utilities --name COSMOS-DB-CONNECTION-STRING --query value -o tsv)" >> $GITHUB_ENV
-            echo "COSMOS_DB_NAME=$(az keyvault secret show --vault-name gh-website-utilities --name COSMOS-DB-NAME --query value -o tsv)" >> $GITHUB_ENV
-            echo "AZURE_STATIC_WEB_APPS_API_TOKEN=$(az keyvault secret show --vault-name gh-website-utilities --name AZURE-STATIC-WEB-APPS-API-TOKEN --query value -o tsv)" >> $GITHUB_ENV
+            COSMOS_DB_CONNECTION_STRING=$(az keyvault secret show --vault-name gh-website-utilities --name COSMOS-DB-CONNECTION-STRING --query value -o tsv)
+            echo "::add-mask::$COSMOS_DB_CONNECTION_STRING"
+            echo "COSMOS_DB_CONNECTION_STRING=$COSMOS_DB_CONNECTION_STRING" >> $GITHUB_ENV
+
+            COSMOS_DB_NAME=$(az keyvault secret show --vault-name gh-website-utilities --name COSMOS-DB-NAME --query value -o tsv)
+            echo "::add-mask::$COSMOS_DB_NAME"
+            echo "COSMOS_DB_NAME=$COSMOS_DB_NAME" >> $GITHUB_ENV
+
+            AZURE_STATIC_WEB_APPS_API_TOKEN=$(az keyvault secret show --vault-name gh-website-utilities --name AZURE-STATIC-WEB-APPS-API-TOKEN --query value -o tsv)
+            echo "::add-mask::$AZURE_STATIC_WEB_APPS_API_TOKEN"
+            echo "AZURE_STATIC_WEB_APPS_API_TOKEN=$AZURE_STATIC_WEB_APPS_API_TOKEN" >> $GITHUB_ENV
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -162,7 +170,9 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            echo "AZURE_STATIC_WEB_APPS_API_TOKEN=$(az keyvault secret show --vault-name gh-website-utilities --name AZURE-STATIC-WEB-APPS-API-TOKEN --query value -o tsv)" >> $GITHUB_ENV
+            AZURE_STATIC_WEB_APPS_API_TOKEN=$(az keyvault secret show --vault-name gh-website-utilities --name AZURE-STATIC-WEB-APPS-API-TOKEN --query value -o tsv)
+            echo "::add-mask::$AZURE_STATIC_WEB_APPS_API_TOKEN"
+            echo "AZURE_STATIC_WEB_APPS_API_TOKEN=$AZURE_STATIC_WEB_APPS_API_TOKEN" >> $GITHUB_ENV
 
       - name: Install OIDC Client from Core Package
         run: npm install @actions/core@1.6.0 @actions/http-client

--- a/.github/workflows/cleanup-cloudinary.yml
+++ b/.github/workflows/cleanup-cloudinary.yml
@@ -22,17 +22,34 @@ on:
         type: string
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Azure login with OIDC
+        uses: azure/login@v2
+        with:
+          client-id: 7d94bc11-9bdf-445b-96c8-fca2560cd441
+          tenant-id: 4122848f-c317-4267-9c07-7c504150d1bd
+          allow-no-subscriptions: true
+
+      - name: Get secrets from Key Vault
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            echo "CLOUDINARY_API_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-KEY --query value -o tsv)" >> $GITHUB_ENV
+            echo "CLOUDINARY_API_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-SECRET --query value -o tsv)" >> $GITHUB_ENV
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -44,9 +61,6 @@ jobs:
         run: npm ci
 
       - name: Run Cloudinary cleanup
-        env:
-          CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
-          CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
         run: |
           ARGS=""
           if [ "${{ inputs.dry_run }}" = "true" ]; then

--- a/.github/workflows/cleanup-cloudinary.yml
+++ b/.github/workflows/cleanup-cloudinary.yml
@@ -48,8 +48,13 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            echo "CLOUDINARY_API_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-KEY --query value -o tsv)" >> $GITHUB_ENV
-            echo "CLOUDINARY_API_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-SECRET --query value -o tsv)" >> $GITHUB_ENV
+            CLOUDINARY_API_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-KEY --query value -o tsv)
+            echo "::add-mask::$CLOUDINARY_API_KEY"
+            echo "CLOUDINARY_API_KEY=$CLOUDINARY_API_KEY" >> $GITHUB_ENV
+
+            CLOUDINARY_API_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-SECRET --query value -o tsv)
+            echo "::add-mask::$CLOUDINARY_API_SECRET"
+            echo "CLOUDINARY_API_SECRET=$CLOUDINARY_API_SECRET" >> $GITHUB_ENV
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/sync-personnel.yml
+++ b/.github/workflows/sync-personnel.yml
@@ -48,6 +48,12 @@ jobs:
             echo "MS_GRAPH_CLIENT_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-SECRET --query value -o tsv)" >> $GITHUB_ENV
             echo "CLOUDINARY_API_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-KEY --query value -o tsv)" >> $GITHUB_ENV
             echo "CLOUDINARY_API_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-SECRET --query value -o tsv)" >> $GITHUB_ENV
+            # Fetch deploy key and mask it in logs
+            DEPLOY_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name DEPLOY-KEY --query value -o tsv)
+            echo "::add-mask::$DEPLOY_KEY"
+            echo "DEPLOY_KEY<<EOF" >> $GITHUB_ENV
+            echo "$DEPLOY_KEY" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -83,7 +89,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+          ssh-private-key: ${{ env.DEPLOY_KEY }}
 
       - name: Commit and push changes
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/sync-personnel.yml
+++ b/.github/workflows/sync-personnel.yml
@@ -16,17 +16,38 @@ on:
           - 'false'
           - 'true'
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   sync-personnel:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    environment: production
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Azure login with OIDC
+        uses: azure/login@v2
+        with:
+          client-id: 7d94bc11-9bdf-445b-96c8-fca2560cd441
+          tenant-id: 4122848f-c317-4267-9c07-7c504150d1bd
+          allow-no-subscriptions: true
+
+      - name: Get secrets from Key Vault
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            echo "MS_GRAPH_TENANT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-TENANT-ID --query value -o tsv)" >> $GITHUB_ENV
+            echo "MS_GRAPH_CLIENT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-ID --query value -o tsv)" >> $GITHUB_ENV
+            echo "MS_GRAPH_CLIENT_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-SECRET --query value -o tsv)" >> $GITHUB_ENV
+            echo "CLOUDINARY_API_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-KEY --query value -o tsv)" >> $GITHUB_ENV
+            echo "CLOUDINARY_API_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-SECRET --query value -o tsv)" >> $GITHUB_ENV
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -38,15 +59,6 @@ jobs:
         run: npm ci
 
       - name: Sync personnel from Microsoft 365
-        env:
-          # Secrets for authentication
-          MS_GRAPH_TENANT_ID: ${{ secrets.MS_GRAPH_TENANT_ID }}
-          MS_GRAPH_CLIENT_ID: ${{ secrets.MS_GRAPH_CLIENT_ID }}
-          MS_GRAPH_CLIENT_SECRET: ${{ secrets.MS_GRAPH_CLIENT_SECRET }}
-          # Cloudinary for photo optimization
-          CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
-          CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
-          # Group IDs and sync settings are in src/_data/site.json
         run: |
           if [ "${{ inputs.force_refresh }}" = "true" ]; then
             node scripts/sync-personnel.mjs --force-refresh

--- a/.github/workflows/sync-personnel.yml
+++ b/.github/workflows/sync-personnel.yml
@@ -43,12 +43,29 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            echo "MS_GRAPH_TENANT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-TENANT-ID --query value -o tsv)" >> $GITHUB_ENV
-            echo "MS_GRAPH_CLIENT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-ID --query value -o tsv)" >> $GITHUB_ENV
-            echo "MS_GRAPH_CLIENT_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-SECRET --query value -o tsv)" >> $GITHUB_ENV
-            echo "CLOUDINARY_API_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-KEY --query value -o tsv)" >> $GITHUB_ENV
-            echo "CLOUDINARY_API_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-SECRET --query value -o tsv)" >> $GITHUB_ENV
-            # Fetch deploy key and mask it in logs
+            # MS Graph secrets
+            MS_GRAPH_TENANT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-TENANT-ID --query value -o tsv)
+            echo "::add-mask::$MS_GRAPH_TENANT_ID"
+            echo "MS_GRAPH_TENANT_ID=$MS_GRAPH_TENANT_ID" >> $GITHUB_ENV
+
+            MS_GRAPH_CLIENT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-ID --query value -o tsv)
+            echo "::add-mask::$MS_GRAPH_CLIENT_ID"
+            echo "MS_GRAPH_CLIENT_ID=$MS_GRAPH_CLIENT_ID" >> $GITHUB_ENV
+
+            MS_GRAPH_CLIENT_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-SECRET --query value -o tsv)
+            echo "::add-mask::$MS_GRAPH_CLIENT_SECRET"
+            echo "MS_GRAPH_CLIENT_SECRET=$MS_GRAPH_CLIENT_SECRET" >> $GITHUB_ENV
+
+            # Cloudinary secrets
+            CLOUDINARY_API_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-KEY --query value -o tsv)
+            echo "::add-mask::$CLOUDINARY_API_KEY"
+            echo "CLOUDINARY_API_KEY=$CLOUDINARY_API_KEY" >> $GITHUB_ENV
+
+            CLOUDINARY_API_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name CLOUDINARY-API-SECRET --query value -o tsv)
+            echo "::add-mask::$CLOUDINARY_API_SECRET"
+            echo "CLOUDINARY_API_SECRET=$CLOUDINARY_API_SECRET" >> $GITHUB_ENV
+
+            # Deploy key (multiline)
             DEPLOY_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name DEPLOY-KEY --query value -o tsv)
             echo "::add-mask::$DEPLOY_KEY"
             echo "DEPLOY_KEY<<EOF" >> $GITHUB_ENV

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,17 +121,32 @@ Personnel data and photos are synced daily from Microsoft 365 via Microsoft Grap
 - `scripts/image-hash.mjs` - Perceptual hashing for photo change detection
 - `.github/workflows/sync-personnel.yml` - Daily scheduled workflow (7 AM UTC)
 
-**Required GitHub Secrets:**
-- `MS_GRAPH_TENANT_ID` - Azure AD tenant ID
-- `MS_GRAPH_CLIENT_ID` - App registration client ID
-- `MS_GRAPH_CLIENT_SECRET` - App registration client secret
-- `CLOUDINARY_API_KEY` - Cloudinary API key (for photo optimization)
-- `CLOUDINARY_API_SECRET` - Cloudinary API secret
+**Secrets (from Key Vault):**
+- `MS-GRAPH-TENANT-ID`, `MS-GRAPH-CLIENT-ID`, `MS-GRAPH-CLIENT-SECRET`
+- `CLOUDINARY-API-KEY`, `CLOUDINARY-API-SECRET`
+- `DEPLOY-KEY` (SSH key for pushing changes)
 
 **Local Testing:**
 ```bash
-export MS_GRAPH_TENANT_ID="your-tenant-id"
-export MS_GRAPH_CLIENT_ID="your-client-id"
-export MS_GRAPH_CLIENT_SECRET="your-client-secret"
+./scripts/pull-secrets.sh    # Populate .env from Key Vault
 npm run sync-personnel
 ```
+
+## Azure Key Vault
+
+All secrets are centralized in Azure Key Vault `gh-website-utilities`. GitHub Actions use OIDC to authenticate and fetch secrets at runtime - no secrets are stored in GitHub.
+
+### Pull secrets locally
+```bash
+./scripts/pull-secrets.sh           # Pull all secrets to .env
+./scripts/pull-secrets.sh --list    # List available secrets
+```
+
+Requires Azure CLI login (`az login`).
+
+### OIDC app registration
+- App: `website-admin` (client ID in workflow files)
+- Federated credentials:
+  - `repo:sjifire/website:environment:production` (scheduled workflows)
+  - `repo:sjifire/website:pull_request` (PR preview builds)
+  - `repo:sjifire/website:ref:refs/heads/main` (manual triggers)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Grant admin consent after adding permissions.
 
 ## Environment Variables
 
+### Azure Static Web App
+
 Set these in Azure Static Web App > Settings > Environment variables:
 
 | Variable | Description |
@@ -89,6 +91,18 @@ Set these in Azure Static Web App > Settings > Environment variables:
 | `MS_GRAPH_CLIENT_SECRET` | MS Graph app client secret |
 | `CLOUDINARY_API_KEY` | Cloudinary API key |
 | `CLOUDINARY_API_SECRET` | Cloudinary API secret |
+
+### Azure Key Vault (for GitHub Actions)
+
+GitHub Actions fetch secrets from Azure Key Vault `gh-website-utilities` using OIDC authentication. No secrets are stored in GitHub.
+
+**Pull secrets for local development:**
+```bash
+./scripts/pull-secrets.sh           # Pull all secrets to .env
+./scripts/pull-secrets.sh --list    # List available secrets
+```
+
+Requires Azure CLI login (`az login`).
 
 ## Authentication Configuration
 

--- a/scripts/pull-secrets.sh
+++ b/scripts/pull-secrets.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Fetches secrets from Azure Key Vault and writes to .env
+# Requires: az cli logged in (run 'az login' first)
+#
+# Usage:
+#   ./scripts/pull-secrets.sh              # Pull all secrets to .env
+#   ./scripts/pull-secrets.sh --all        # Same as above
+#   ./scripts/pull-secrets.sh SECRET-NAME  # Pull specific secret(s)
+#   ./scripts/pull-secrets.sh --list       # List available secrets
+
+set -e
+
+VAULT="gh-website-utilities"
+OUTPUT_FILE=".env"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if az cli is logged in
+if ! az account show &>/dev/null; then
+    echo -e "${RED}Error: Not logged in to Azure CLI${NC}"
+    echo "Run 'az login' first"
+    exit 1
+fi
+
+# List secrets
+if [ "$1" = "--list" ]; then
+    echo "Available secrets in $VAULT:"
+    az keyvault secret list --vault-name "$VAULT" --query "[].name" -o tsv | sort
+    exit 0
+fi
+
+# Determine which secrets to fetch
+if [ $# -eq 0 ] || [ "$1" = "--all" ]; then
+    echo -e "${YELLOW}Fetching all secrets from $VAULT...${NC}"
+    SECRETS=$(az keyvault secret list --vault-name "$VAULT" --query "[].name" -o tsv)
+else
+    SECRETS="$@"
+fi
+
+# Clear or create .env file
+> "$OUTPUT_FILE"
+
+# Fetch each secret
+for name in $SECRETS; do
+    echo -n "  $name... "
+    value=$(az keyvault secret show --vault-name "$VAULT" --name "$name" --query value -o tsv 2>/dev/null)
+    if [ $? -eq 0 ] && [ -n "$value" ]; then
+        # Convert hyphens to underscores for env var name
+        env_name=$(echo "$name" | tr '-' '_')
+        echo "${env_name}=${value}" >> "$OUTPUT_FILE"
+        echo -e "${GREEN}OK${NC}"
+    else
+        echo -e "${RED}FAILED${NC}"
+    fi
+done
+
+echo -e "\n${GREEN}Secrets written to $OUTPUT_FILE${NC}"
+echo -e "${YELLOW}Remember: Don't commit .env to git!${NC}"

--- a/src/_data/personnel.json
+++ b/src/_data/personnel.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-01-31T07:14:33.849Z",
+  "generated": "2026-01-31T20:52:18.897Z",
   "count": 58,
   "counts": {
     "fullTimeFirefighters": 9,

--- a/src/assets/media/personnel_imgs/.photo-hashes.json
+++ b/src/assets/media/personnel_imgs/.photo-hashes.json
@@ -1,7 +1,7 @@
 {
   "adam_greene.jpg": "f806f18e017e03fe33fe73077007f007f037f027e127e223f3b9e3dde188e004",
   "alexa_rust.jpg": "0fe01fe03fe0fc60fc20fb90fb80fb80fbc0fb80f381f380f39add18be409e60",
-  "bonnie_stanger.jpg": "0fc01fe03ff0fc30fc38f818f810ff30fc30ff70fc30f200e7c0c783c36398f1",
+  "bonnie_stanger.jpg": "0fc01fe03ff0fc30fc38f818f810ff30fc30ff70fc30f200f7c0c783c36388f1",
   "brad_smith.jpg": "03c00fe03ff07ff0fc38f838fc38f810fe38ff38fa10e100ff89f818be103e60",
   "chad_warmenhoven.jpg": "03c01fe03ff07e783d3079b0f838fc38fd38fc38fc38f000fc02dc31cc70de71",
   "charles_genther.jpg": "07801fe03fe07ff07d20fd30fc30fc30fe70fff0f3c0c000fc01de10de709ef0",
@@ -18,7 +18,7 @@
   "karen_gentry.jpg": "03c00fe03ff07ff07e607c30fdb0fc10ff38fe38fc10f000fe00ef20cf70ce70",
   "karl_kuetzing.jpg": "03c00fe03ff07ff0feb0fc18fc10fc10ffb8ff3cf800e000ff10efe1cfe0c040",
   "kathleen_salinas.jpg": "0fe01ff07e387c18f80cf90ef80ef80ef80ef80efc1af80aff8fa5819980be88",
-  "kati_english.jpg": "1fe03ff07c30f910f990fa90fb90fc10fff0fd38f100e180fdb2de32ce618301",
+  "kati_english.jpg": "1fe03ff07c30f910f990fa90fb90fc10ffb8fd38f100e180fdb2de32ce618301",
   "kyle_dodd.jpg": "07c01fe03ff07db0f930fc30fc30fc30ff39ff39f180c000fe33be639e618401",
   "matthew_wickey.jpg": "07c01fe03ff0fe30fc38fc10fc18fd10ffb8ffb0f810e000f800fe12de3acc78",
   "michael_hartzell.jpg": "07c01fe07e70fdb0fd90fc10fd30fc20ffb1ff19f101c001df399ff19fe10000",


### PR DESCRIPTION
## Summary
- Replace ALL GitHub repository secrets with Azure Key Vault for centralized secret management
- Use OIDC (OpenID Connect) for passwordless authentication from GitHub Actions to Azure
- Secrets are fetched at runtime from `gh-website-utilities` vault
- Add `pull-secrets.sh` script for local development

## Changes

### Workflows Updated
- **sync-personnel.yml**: Fetch MS Graph, Cloudinary, and DEPLOY_KEY from Key Vault
- **cleanup-cloudinary.yml**: Fetch Cloudinary secrets from Key Vault
- **azure-static-web-apps-*.yml**: Fetch COSMOS_DB_* and SWA API token from Key Vault

### New Files
- `scripts/pull-secrets.sh` - Fetch secrets from Key Vault to local `.env`

### Documentation
- Updated README.md with Key Vault section
- Updated CLAUDE.md with Key Vault configuration and OIDC details

## Azure Configuration
- **Key Vault**: `gh-website-utilities` in `rg-staticweb-prod-westus2`
- **App Registration**: `website-admin` with federated credentials:
  - `repo:sjifire/website:environment:production` (scheduled workflows)
  - `repo:sjifire/website:pull_request` (PR preview builds)
  - `repo:sjifire/website:ref:refs/heads/main` (manual triggers, workflow_run)
- **Access Policy**: `website-admin` has `get` and `list` permissions on secrets

## Secrets in Vault (used by this repo)
- `MS-GRAPH-TENANT-ID`, `MS-GRAPH-CLIENT-ID`, `MS-GRAPH-CLIENT-SECRET`
- `CLOUDINARY-API-KEY`, `CLOUDINARY-API-SECRET`
- `COSMOS-DB-CONNECTION-STRING`, `COSMOS-DB-NAME`
- `AZURE-STATIC-WEB-APPS-API-TOKEN`
- `DEPLOY-KEY`

## GitHub Secrets No Longer Needed
After merge, these GitHub secrets can be removed:
- `MS_GRAPH_TENANT_ID`, `MS_GRAPH_CLIENT_ID`, `MS_GRAPH_CLIENT_SECRET`
- `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`
- `COSMOS_DB_CONNECTION_STRING`, `COSMOS_DB_NAME`
- `AZURE_STATIC_WEB_APPS_API_TOKEN_JOLLY_MOSS_0DB15021E`
- `DEPLOY_KEY`

## Test plan
- [ ] Trigger sync-personnel workflow manually to verify OIDC + Key Vault
- [ ] Trigger cleanup-cloudinary workflow with dry-run
- [ ] Create a test PR to verify azure-static-web-apps workflow with PR preview
- [ ] Verify scheduled runs work correctly after merge