### PR TITLE
Add Deckhand role to Marine Crew classification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Personnel data and photos are synced daily from Microsoft 365 via Microsoft Grap
   - Users without employeeType are excluded
 - `extensionAttribute1` - Rank (Chief, Battalion Chief, Captain, Lieutenant, etc.)
 - `extensionAttribute2` - Apparatus Operator certification expiration date (if future date, adds "Apparatus Operator" role)
-- `extensionAttribute3` - Comma-separated roles, simplified to: Marine (Mate/Pilot), Firefighter, Wildland Firefighter, Support
+- `extensionAttribute3` - Comma-separated roles, simplified to: Marine Crew (Marine: Mate/Pilot/Deckhand), Firefighter, Wildland Firefighter, Support
 - `jobTitle` - Display title
 
 **Files:**

--- a/scripts/sync-personnel.mjs
+++ b/scripts/sync-personnel.mjs
@@ -113,8 +113,8 @@ function determineRoles(extAttrs) {
 
   const roleList = rawRoles.split(",").map(r => r.trim().toLowerCase());
 
-  // Marine Crew (Mate or Pilot)
-  if (roleList.includes("mate") || roleList.includes("pilot")) {
+  // Marine Crew (Mate, Pilot, or Deckhand)
+  if (roleList.some(r => r.includes("mate") || r.includes("pilot") || r.includes("deckhand"))) {
     roles.push("Marine Crew");
   }
 


### PR DESCRIPTION
## Summary
Updated the Marine Crew role classification to include "Deckhand" as a valid marine position alongside existing Mate and Pilot roles.

## Changes
  - Check for "deckhand" in addition to "mate" and "pilot"
  - Changed from direct equality checks to substring matching using `includes()` for more flexible role name matching
