### PR TITLE
Fix sync-personnel workflow: use GitHub App instead of empty deploy key

### DIFF
--- a/.github/workflows/sync-personnel.yml
+++ b/.github/workflows/sync-personnel.yml
@@ -71,12 +71,15 @@ jobs:
             echo "GH_APP_ID=$GH_APP_ID" >> $GITHUB_ENV
 
             # Private key is stored base64-encoded in Key Vault
+            # Mask the base64 version (single-line, works with add-mask)
             GH_APP_PRIVATE_KEY_B64=$(az keyvault secret show --vault-name gh-website-utilities --name GITHUB-APP-PRIVATE-KEY --query value -o tsv)
-            GH_APP_PRIVATE_KEY=$(echo "$GH_APP_PRIVATE_KEY_B64" | base64 -d)
-            echo "::add-mask::$GH_APP_PRIVATE_KEY"
-            echo "GH_APP_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
-            echo "$GH_APP_PRIVATE_KEY" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
+            echo "::add-mask::$GH_APP_PRIVATE_KEY_B64"
+            # Decode and write directly to env file without echoing to logs
+            {
+              echo "GH_APP_PRIVATE_KEY<<EOF"
+              echo "$GH_APP_PRIVATE_KEY_B64" | base64 -d
+              echo "EOF"
+            } >> $GITHUB_ENV
 
       - name: Validate required secrets
         run: |

--- a/.github/workflows/sync-personnel.yml
+++ b/.github/workflows/sync-personnel.yml
@@ -70,7 +70,9 @@ jobs:
             echo "::add-mask::$GH_APP_ID"
             echo "GH_APP_ID=$GH_APP_ID" >> $GITHUB_ENV
 
-            GH_APP_PRIVATE_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name GITHUB-APP-PRIVATE-KEY --query value -o tsv)
+            # Private key is stored base64-encoded in Key Vault
+            GH_APP_PRIVATE_KEY_B64=$(az keyvault secret show --vault-name gh-website-utilities --name GITHUB-APP-PRIVATE-KEY --query value -o tsv)
+            GH_APP_PRIVATE_KEY=$(echo "$GH_APP_PRIVATE_KEY_B64" | base64 -d)
             echo "::add-mask::$GH_APP_PRIVATE_KEY"
             echo "GH_APP_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
             echo "$GH_APP_PRIVATE_KEY" >> $GITHUB_ENV

--- a/.github/workflows/sync-personnel.yml
+++ b/.github/workflows/sync-personnel.yml
@@ -72,6 +72,21 @@ jobs:
             echo "$DEPLOY_KEY" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
 
+      - name: Validate required secrets
+        run: |
+          missing=""
+          [ -z "$MS_GRAPH_TENANT_ID" ] && missing="$missing MS-GRAPH-TENANT-ID"
+          [ -z "$MS_GRAPH_CLIENT_ID" ] && missing="$missing MS-GRAPH-CLIENT-ID"
+          [ -z "$MS_GRAPH_CLIENT_SECRET" ] && missing="$missing MS-GRAPH-CLIENT-SECRET"
+          [ -z "$CLOUDINARY_API_KEY" ] && missing="$missing CLOUDINARY-API-KEY"
+          [ -z "$CLOUDINARY_API_SECRET" ] && missing="$missing CLOUDINARY-API-SECRET"
+          [ -z "$DEPLOY_KEY" ] && missing="$missing DEPLOY-KEY"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing or empty secrets in Key Vault:$missing"
+            exit 1
+          fi
+          echo "All required secrets are present"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/sync-personnel.yml
+++ b/.github/workflows/sync-personnel.yml
@@ -65,11 +65,15 @@ jobs:
             echo "::add-mask::$CLOUDINARY_API_SECRET"
             echo "CLOUDINARY_API_SECRET=$CLOUDINARY_API_SECRET" >> $GITHUB_ENV
 
-            # Deploy key (multiline)
-            DEPLOY_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name DEPLOY-KEY --query value -o tsv)
-            echo "::add-mask::$DEPLOY_KEY"
-            echo "DEPLOY_KEY<<EOF" >> $GITHUB_ENV
-            echo "$DEPLOY_KEY" >> $GITHUB_ENV
+            # GitHub App secrets (for pushing changes)
+            GH_APP_ID=$(az keyvault secret show --vault-name gh-website-utilities --name GITHUB-APP-ID --query value -o tsv)
+            echo "::add-mask::$GH_APP_ID"
+            echo "GH_APP_ID=$GH_APP_ID" >> $GITHUB_ENV
+
+            GH_APP_PRIVATE_KEY=$(az keyvault secret show --vault-name gh-website-utilities --name GITHUB-APP-PRIVATE-KEY --query value -o tsv)
+            echo "::add-mask::$GH_APP_PRIVATE_KEY"
+            echo "GH_APP_PRIVATE_KEY<<EOF" >> $GITHUB_ENV
+            echo "$GH_APP_PRIVATE_KEY" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
 
       - name: Validate required secrets
@@ -80,7 +84,8 @@ jobs:
           [ -z "$MS_GRAPH_CLIENT_SECRET" ] && missing="$missing MS-GRAPH-CLIENT-SECRET"
           [ -z "$CLOUDINARY_API_KEY" ] && missing="$missing CLOUDINARY-API-KEY"
           [ -z "$CLOUDINARY_API_SECRET" ] && missing="$missing CLOUDINARY-API-SECRET"
-          [ -z "$DEPLOY_KEY" ] && missing="$missing DEPLOY-KEY"
+          [ -z "$GH_APP_ID" ] && missing="$missing GITHUB-APP-ID"
+          [ -z "$GH_APP_PRIVATE_KEY" ] && missing="$missing GITHUB-APP-PRIVATE-KEY"
           if [ -n "$missing" ]; then
             echo "::error::Missing or empty secrets in Key Vault:$missing"
             exit 1
@@ -117,18 +122,20 @@ jobs:
             git diff --cached --name-only >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Setup SSH deploy key
+      - name: Generate GitHub App token
+        id: app-token
         if: steps.changes.outputs.changed == 'true'
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: actions/create-github-app-token@v1
         with:
-          ssh-private-key: ${{ env.DEPLOY_KEY }}
+          app-id: ${{ env.GH_APP_ID }}
+          private-key: ${{ env.GH_APP_PRIVATE_KEY }}
 
       - name: Commit and push changes
         if: steps.changes.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin git@github.com:${{ github.repository }}.git
+          git config user.name "sjifire-bot[bot]"
+          git config user.email "${{ env.GH_APP_ID }}+sjifire-bot[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
           git commit -m "chore: sync personnel data from Microsoft 365
 
           Auto-generated daily update of personnel information.

--- a/src/_data/personnel.json
+++ b/src/_data/personnel.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-02-01T04:45:00.314Z",
+  "generated": "2026-02-01T04:50:39.394Z",
   "count": 58,
   "counts": {
     "fullTimeFirefighters": 9,

--- a/src/_data/personnel.json
+++ b/src/_data/personnel.json
@@ -1,12 +1,12 @@
 {
-  "generated": "2026-01-31T20:52:18.897Z",
+  "generated": "2026-02-01T04:45:00.314Z",
   "count": 58,
   "counts": {
     "fullTimeFirefighters": 9,
     "partTimeFirefighters": 4,
     "administrativeStaff": 2,
-    "volunteerFirefighters": 36,
-    "volunteerSupport": 7
+    "volunteerFirefighters": 37,
+    "volunteerSupport": 6
   },
   "personnel": [
     {
@@ -31,8 +31,7 @@
       "staff_type": "Day Staff",
       "roles": [
         "Apparatus Operator",
-        "Firefighter",
-        "Marine Crew"
+        "Firefighter"
       ],
       "photo": "/assets/media/personnel_imgs/michael_hartzell.jpg"
     },
@@ -219,8 +218,7 @@
       "staff_type": "Volunteer",
       "roles": [
         "Apparatus Operator",
-        "Firefighter",
-        "Marine Crew"
+        "Firefighter"
       ],
       "photo": "/assets/media/personnel_imgs/erin_graham.jpg"
     },
@@ -463,6 +461,7 @@
       "employee_type": "volunteer",
       "staff_type": "Volunteer",
       "roles": [
+        "Marine Crew",
         "Support"
       ],
       "photo": "/assets/media/personnel_imgs/hella_cascorbi.jpg"
@@ -487,6 +486,7 @@
       "employee_type": "volunteer",
       "staff_type": "Volunteer",
       "roles": [
+        "Marine Crew",
         "Wildland Firefighter"
       ],
       "photo": null
@@ -697,7 +697,8 @@
       "staff_type": "Volunteer",
       "roles": [
         "Apparatus Operator",
-        "Firefighter"
+        "Firefighter",
+        "Marine Crew"
       ],
       "photo": null
     },


### PR DESCRIPTION
## Summary
- The `DEPLOY-KEY` secret in Key Vault was created but never populated with an SSH private key, causing the sync-personnel workflow to fail
- Reverts to using GitHub App authentication (sjifire-bot), which was the original approach and has working secrets
- Adds validation step to fail fast with clear error messages when secrets are missing

## Changes
1. Fetch `GITHUB-APP-ID` and `GITHUB-APP-PRIVATE-KEY` from Key Vault instead of `DEPLOY-KEY`
2. Use `actions/create-github-app-token` to generate ephemeral tokens
3. Push via HTTPS with app token instead of SSH
4. Commits will appear as "sjifire-bot[bot]"

## Test plan
- [x] Merge and manually trigger the sync-personnel workflow
- [x] Verify workflow completes successfully
- [x] Verify commits (if any) are authored by sjifire-bot[bot]