### PR TITLE
fix: remove generated timestamp from personnel.json to prevent false changes

### DIFF
--- a/scripts/sync-personnel.mjs
+++ b/scripts/sync-personnel.mjs
@@ -385,7 +385,6 @@ function computeCounts(personnel) {
 async function writePersonnelJson(personnel) {
   const counts = computeCounts(personnel);
   const output = {
-    generated: new Date().toISOString(),
     count: personnel.length,
     counts,
     personnel: personnel,


### PR DESCRIPTION
The personnel sync was committing on every run even when data hadn't changed
because the JSON output included a `generated` timestamp that updated each run.
Removing this field allows git to correctly detect when the actual personnel
data is unchanged.

https://claude.ai/code/session_01B8XnDdrRJTG1VVURJ1s1da