### PR TITLE
Add authenticated members portal page

### DIFF
--- a/scripts/cleanup-cloudinary.mjs
+++ b/scripts/cleanup-cloudinary.mjs
@@ -208,9 +208,10 @@ async function main() {
         console.log(`  Deleted ${deletedCount}/${staleList.length}...`);
       }
     } catch (error) {
-      console.error(`  Failed to delete ${item.publicId}: ${error.message}`);
+      const errorMsg = error.message || String(error);
+      console.error(`  Failed to delete ${item.publicId}: ${errorMsg}`);
       // On rate limit errors, wait longer before continuing
-      if (error.message.includes("420") || error.message.includes("Rate")) {
+      if (errorMsg.includes("420") || errorMsg.includes("Rate")) {
         console.log("  Rate limited, waiting 60 seconds...");
         await setTimeout(60000);
       }

--- a/src/_includes/footer.liquid
+++ b/src/_includes/footer.liquid
@@ -32,7 +32,7 @@
 
   <dl class="footer-navgroup">
     <dt class="footer-heading">Resources</dt>
-    <dd class="footer-navlink"><a href="https://www.office.com/?auth=2">Member Login</a></dd>
+    <dd class="footer-navlink"><a href="/.auth/login/aad?post_login_redirect_uri=/members/">Member Portal</a></dd>
     <dd class="footer-navlink"><a href="https://www.islandsready.org/">SJC Department of Emergency Management</a></dd>
     <dd class="footer-navlink"><a href="https://www.sanjuancountywa.gov/2169/Health-Community-Services">SJC Community Health</a></dd>
     <dd class="footer-navlink"><a href="https://www.sanjuancountywa.gov/1088/Fire-Marshal">SJC Fire Marshal</a></dd>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -5,19 +5,19 @@ nav_hidden: true
 ---
 
 <div class="card-grid">
-  <a href="https://mcp.sjifire.org/dashboard" class="card card--link">
+  <a href="https://mcp.sjifire.org/dashboard" class="card card--link" target="_blank" rel="noopener">
     <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
     <h3>Incident Dashboard</h3>
     <p>View real-time incident data.</p>
   </a>
 
-  <a href="https://claude.ai" class="card card--link">
+  <a href="https://claude.ai" class="card card--link" target="_blank" rel="noopener">
     <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
     <h3>Incident Reports</h3>
     <p>Use Claude AI to write incident reports.</p>
   </a>
 
-  <a href="https://www.office.com/?auth=2" class="card card--link">
+  <a href="https://www.office.com/?auth=2" class="card card--link" target="_blank" rel="noopener">
     <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
     <h3>Office 365</h3>
     <p>Email, SharePoint, Teams.</p>
@@ -25,7 +25,7 @@ nav_hidden: true
 
   <a href="/admin/" class="card card--link">
     <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-    <h3>TinaCMS Admin</h3>
+    <h3>Website Admin</h3>
     <p>Website content management. Requires additional admin permissions.</p>
   </a>
 </div>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -1,0 +1,31 @@
+---
+title: "Member Portal"
+layout: page
+nav_hidden: true
+---
+
+<div class="card-grid">
+  <a href="https://mcp.sjifire.org/dashboard" class="card card--link">
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+    <h3>Incident Dashboard</h3>
+    <p>View real-time incident data.</p>
+  </a>
+
+  <a href="https://claude.ai" class="card card--link">
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+    <h3>Incident Reports</h3>
+    <p>Use Claude AI to write incident reports.</p>
+  </a>
+
+  <a href="https://www.office.com/?auth=2" class="card card--link">
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+    <h3>Office 365</h3>
+    <p>Email, SharePoint, Teams.</p>
+  </a>
+
+  <a href="/admin/" class="card card--link">
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+    <h3>TinaCMS Admin</h3>
+    <p>Website content management. Requires additional admin permissions.</p>
+  </a>
+</div>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -23,7 +23,7 @@ nav_hidden: true
     <p>Email, SharePoint, Teams.</p>
   </a>
 
-  <a href="/admin/" class="card card--link">
+  <a href="/admin/" class="card card--link" target="_blank" rel="noopener">
     <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
     <h3>Website Admin</h3>
     <p>Website content management. Requires additional admin permissions.</p>

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -20,6 +20,10 @@
       "allowedRoles": ["anonymous", "authenticated"]
     },
     {
+      "route": "/members/*",
+      "allowedRoles": ["authenticated"]
+    },
+    {
       "route": "/admin/*",
       "allowedRoles": ["admin"]
     },


### PR DESCRIPTION
## Summary
- Create `/members/` portal page with cards linking to Incident Dashboard, Claude AI for reports, Office 365, and TinaCMS Admin
- Protect `/members/*` route with Azure AD `authenticated` role in `staticwebapp.config.json`
- Update footer "Member Login" link to "Member Portal" triggering AAD auth flow with redirect to `/members/`

## Test plan
- [x] `npm run dev` — page renders at `localhost:8080/members/` with card grid layout
- [x] Footer shows "Member Portal" with `/.auth/login/aad?post_login_redirect_uri=/members/` href
- [x] After deploy: clicking "Member Portal" → Azure AD login → lands on `/members/`
- [x] Unauthenticated users are redirected to Azure AD login
- [x] All four card links resolve correctly