### PR TITLE
Expand members portal with additional links

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1174,13 +1174,9 @@ body {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-a.card--link:hover {
+.card--link:hover {
   transform: translateY(-4px);
   box-shadow: 0 4px 16px rgb(0, 0, 0, 0.2);
-}
-
-div.card--link {
-  border-left: 4px solid var(--red);
 }
 
 .card--link h3 {

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1174,9 +1174,13 @@ body {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.card--link:hover {
+a.card--link:hover {
   transform: translateY(-4px);
   box-shadow: 0 4px 16px rgb(0, 0, 0, 0.2);
+}
+
+div.card--link {
+  border-left: 4px solid var(--red);
 }
 
 .card--link h3 {

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -13,16 +13,12 @@ nav_hidden: true
 <h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>Communication</h2>
 <ul>
   <li>Office 365 &mdash; <a href="https://outlook.office.com" target="_blank" rel="noopener">Outlook</a> | <a href="https://teams.microsoft.com" target="_blank" rel="noopener">Teams</a> | <a href="https://sjifires.sharepoint.com" target="_blank" rel="noopener">SharePoint</a></li>
-  <li><a href="https://secure17.aladtec.com/sjifire" target="_blank" rel="noopener">Aladtec</a> &mdash; Scheduling</li>
+  <li>Aladtec &mdash; <a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_schedule_my_schedule" target="_blank" rel="noopener">Schedule</a> | <a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_members_view_member_information" target="_blank" rel="noopener">Info</a></li>
   <li><a href="https://sjf3.ispyfire.com/me.html" target="_blank" rel="noopener">iSpyFire</a> &mdash; Dispatch alerting</li>
-</ul>
-
-<h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Reference</h2>
-<ul>
-  <li><a href="https://app.lexipol.com/dashboard" target="_blank" rel="noopener">Lexipol</a> &mdash; Policies &amp; daily training</li>
 </ul>
 
 <h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>Misc</h2>
 <ul>
+  <li><a href="https://app.lexipol.com/dashboard" target="_blank" rel="noopener">Lexipol</a> &mdash; Policies &amp; daily training</li>
   <li><a href="/admin/" target="_blank" rel="noopener">Website Admin</a> &mdash; Requires additional permissions</li>
 </ul>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -11,11 +11,15 @@ nav_hidden: true
     <p>View real-time incident data.</p>
   </a>
 
-  <a href="https://claude.ai" class="card card--link" target="_blank" rel="noopener">
+  <div class="card card--link">
     <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
     <h3>Incident Reports</h3>
-    <p>Use Claude AI to write incident reports.</p>
-  </a>
+    <p>
+      <a href="https://claude.ai" target="_blank" rel="noopener">Open Claude.ai</a> |
+      <a href="FIXME">Setup</a> |
+      <a href="FIXME">Hints &amp; Tricks</a>
+    </p>
+  </div>
 
   <div class="card card--link">
     <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -4,25 +4,25 @@ layout: page
 nav_hidden: true
 ---
 
-<h2>Incident Management</h2>
+<h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>Incident Management</h2>
 <ul>
   <li><a href="https://mcp.sjifire.org/dashboard" target="_blank" rel="noopener">Incident Dashboard</a></li>
-  <li>Incident Reports &mdash; <a href="https://claude.ai" target="_blank" rel="noopener">Claude.ai</a> | <a href="FIXME">Setup</a> | <a href="FIXME">Hints &amp; Tricks</a></li>
+  <li>Incident Reports &mdash; <a href="https://claude.ai" target="_blank" rel="noopener">Start Session</a> | <a href="FIXME">Setup</a> | <a href="FIXME">Hints &amp; Tricks</a></li>
 </ul>
 
-<h2>Communication</h2>
+<h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>Communication</h2>
 <ul>
   <li>Office 365 &mdash; <a href="https://outlook.office.com" target="_blank" rel="noopener">Outlook</a> | <a href="https://teams.microsoft.com" target="_blank" rel="noopener">Teams</a> | <a href="https://sjifires.sharepoint.com" target="_blank" rel="noopener">SharePoint</a></li>
   <li><a href="https://secure17.aladtec.com/sjifire" target="_blank" rel="noopener">Aladtec</a> &mdash; Scheduling</li>
   <li><a href="https://sjf3.ispyfire.com/me.html" target="_blank" rel="noopener">iSpyFire</a> &mdash; Dispatch alerting</li>
 </ul>
 
-<h2>Reference</h2>
+<h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>Reference</h2>
 <ul>
   <li><a href="https://app.lexipol.com/dashboard" target="_blank" rel="noopener">Lexipol</a> &mdash; Policies &amp; daily training</li>
 </ul>
 
-<h2>Misc</h2>
+<h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>Misc</h2>
 <ul>
   <li><a href="/admin/" target="_blank" rel="noopener">Website Admin</a> &mdash; Requires additional permissions</li>
 </ul>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -4,21 +4,58 @@ layout: page
 nav_hidden: true
 ---
 
+<style>
+  .portal-list { list-style: none; padding: 0; margin: 0 0 1.5rem; }
+  .portal-list li { margin-bottom: 1rem; }
+  .portal-list .service { font-weight: 600; }
+  .portal-list .links { margin-left: 0.25rem; }
+  .portal-list .links .sep { color: #999; }
+  .portal-list .desc { display: block; font-size: 0.9rem; color: #666; margin-top: 0.15rem; }
+</style>
+
 <h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>Incident Management</h2>
-<ul>
-  <li><a href="https://mcp.sjifire.org/dashboard" target="_blank" rel="noopener">Incident Dashboard</a></li>
-  <li>Incident Reports &mdash; <a href="https://ops.sjifire.org/dashboard#reports" target="_blank" rel="noopener">Internal</a> | <a href="https://neris.fsri.org/signin" target="_blank" rel="noopener">NERIS</a> (requires additional permissions)</li>
+<ul class="portal-list">
+  <li>
+    <span class="service">Incident Dashboard</span> &mdash;
+    <span class="links"><a href="https://mcp.sjifire.org/dashboard" target="_blank" rel="noopener">View</a></span>
+    <span class="desc">Real-time incident data</span>
+  </li>
+  <li>
+    <span class="service">Incident Reports</span> &mdash;
+    <span class="links"><a href="https://ops.sjifire.org/dashboard#reports" target="_blank" rel="noopener">Internal</a> <span class="sep">|</span> <a href="https://neris.fsri.org/signin" target="_blank" rel="noopener">NERIS</a></span>
+    <span class="desc">Requires additional permissions</span>
+  </li>
 </ul>
 
 <h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>Communication</h2>
-<ul>
-  <li>Office 365 &mdash; <a href="https://outlook.office.com" target="_blank" rel="noopener">Outlook</a> | <a href="https://teams.microsoft.com" target="_blank" rel="noopener">Teams</a> | <a href="https://sjifires.sharepoint.com" target="_blank" rel="noopener">SharePoint</a></li>
-  <li>Aladtec &mdash; <a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_schedule_my_schedule" target="_blank" rel="noopener">Schedule</a> | <a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_members_view_member_information" target="_blank" rel="noopener">My Info</a></li>
-  <li><a href="https://sjf3.ispyfire.com/me.html" target="_blank" rel="noopener">iSpyFire</a> &mdash; Dispatch alerting</li>
+<ul class="portal-list">
+  <li>
+    <span class="service">Office 365</span> &mdash;
+    <span class="links"><a href="https://outlook.office.com" target="_blank" rel="noopener">Outlook</a> <span class="sep">|</span> <a href="https://teams.microsoft.com" target="_blank" rel="noopener">Teams</a> <span class="sep">|</span> <a href="https://sjifires.sharepoint.com" target="_blank" rel="noopener">SharePoint</a></span>
+    <span class="desc">Email, calendar, and files</span>
+  </li>
+  <li>
+    <span class="service">Aladtec</span> &mdash;
+    <span class="links"><a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_schedule_my_schedule" target="_blank" rel="noopener">Schedule</a> <span class="sep">|</span> <a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_members_view_member_information" target="_blank" rel="noopener">My Info</a></span>
+    <span class="desc">Scheduling and shift management</span>
+  </li>
+  <li>
+    <span class="service">iSpyFire</span> &mdash;
+    <span class="links"><a href="https://sjf3.ispyfire.com/me.html" target="_blank" rel="noopener">Open</a></span>
+    <span class="desc">Mobile dispatch alerting</span>
+  </li>
 </ul>
 
 <h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>Misc</h2>
-<ul>
-  <li><a href="https://app.lexipol.com/dashboard" target="_blank" rel="noopener">Lexipol</a> &mdash; Policies &amp; daily training</li>
-  <li><a href="/admin/" target="_blank" rel="noopener">Website Admin</a> &mdash; Requires additional permissions</li>
+<ul class="portal-list">
+  <li>
+    <span class="service">Lexipol</span> &mdash;
+    <span class="links"><a href="https://app.lexipol.com/dashboard" target="_blank" rel="noopener">Dashboard</a></span>
+    <span class="desc">Policies and daily training</span>
+  </li>
+  <li>
+    <span class="service">Website Admin</span> &mdash;
+    <span class="links"><a href="/admin/" target="_blank" rel="noopener">Open</a></span>
+    <span class="desc">Content management; requires additional permissions</span>
+  </li>
 </ul>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -7,7 +7,7 @@ nav_hidden: true
 <h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>Incident Management</h2>
 <ul>
   <li><a href="https://mcp.sjifire.org/dashboard" target="_blank" rel="noopener">Incident Dashboard</a></li>
-  <li>Incident Reports &mdash; <a href="https://claude.ai" target="_blank" rel="noopener">Start Session</a> | <a href="FIXME">Setup</a> | <a href="FIXME">Hints &amp; Tricks</a></li>
+  <li>Incident Reports &mdash; <a href="https://ops.sjifire.org/dashboard#reports" target="_blank" rel="noopener">Internal</a> | <a href="https://neris.fsri.org/signin" target="_blank" rel="noopener">NERIS</a> (requires additional permissions)</li>
 </ul>
 
 <h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>Communication</h2>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -22,7 +22,7 @@ nav_hidden: true
   <li><a href="https://app.lexipol.com/dashboard" target="_blank" rel="noopener">Lexipol</a> &mdash; Policies &amp; daily training</li>
 </ul>
 
-<h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>Misc</h2>
+<h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>Misc</h2>
 <ul>
   <li><a href="/admin/" target="_blank" rel="noopener">Website Admin</a> &mdash; Requires additional permissions</li>
 </ul>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -13,7 +13,7 @@ nav_hidden: true
 <h2><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align: -4px; margin-right: 6px;"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>Communication</h2>
 <ul>
   <li>Office 365 &mdash; <a href="https://outlook.office.com" target="_blank" rel="noopener">Outlook</a> | <a href="https://teams.microsoft.com" target="_blank" rel="noopener">Teams</a> | <a href="https://sjifires.sharepoint.com" target="_blank" rel="noopener">SharePoint</a></li>
-  <li>Aladtec &mdash; <a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_schedule_my_schedule" target="_blank" rel="noopener">Schedule</a> | <a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_members_view_member_information" target="_blank" rel="noopener">Info</a></li>
+  <li>Aladtec &mdash; <a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_schedule_my_schedule" target="_blank" rel="noopener">Schedule</a> | <a href="https://secure17.aladtec.com/sjifire/index.php?action=manage_members_view_member_information" target="_blank" rel="noopener">My Info</a></li>
   <li><a href="https://sjf3.ispyfire.com/me.html" target="_blank" rel="noopener">iSpyFire</a> &mdash; Dispatch alerting</li>
 </ul>
 

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -22,7 +22,7 @@ nav_hidden: true
   <li><a href="https://app.lexipol.com/dashboard" target="_blank" rel="noopener">Lexipol</a> &mdash; Policies &amp; daily training</li>
 </ul>
 
-<h2>Administration</h2>
+<h2>Misc</h2>
 <ul>
   <li><a href="/admin/" target="_blank" rel="noopener">Website Admin</a> &mdash; Requires additional permissions</li>
 </ul>

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -17,10 +17,32 @@ nav_hidden: true
     <p>Use Claude AI to write incident reports.</p>
   </a>
 
-  <a href="https://www.office.com/?auth=2" class="card card--link" target="_blank" rel="noopener">
+  <div class="card card--link">
     <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
     <h3>Office 365</h3>
-    <p>Email, SharePoint, Teams.</p>
+    <p>
+      <a href="https://outlook.office.com" target="_blank" rel="noopener">Outlook</a> |
+      <a href="https://teams.microsoft.com" target="_blank" rel="noopener">Teams</a> |
+      <a href="https://sjifires.sharepoint.com" target="_blank" rel="noopener">SharePoint</a>
+    </p>
+  </div>
+
+  <a href="https://secure17.aladtec.com/sjifire" class="card card--link" target="_blank" rel="noopener">
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+    <h3>Aladtec</h3>
+    <p>Scheduling and shift management.</p>
+  </a>
+
+  <a href="https://app.lexipol.com/dashboard" class="card card--link" target="_blank" rel="noopener">
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+    <h3>Lexipol</h3>
+    <p>Policies and daily training bulletins.</p>
+  </a>
+
+  <a href="https://sjf3.ispyfire.com/me.html" class="card card--link" target="_blank" rel="noopener">
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+    <h3>iSpyFire</h3>
+    <p>Mobile dispatch alerting.</p>
   </a>
 
   <a href="/admin/" class="card card--link" target="_blank" rel="noopener">

--- a/src/pages/members.liquid
+++ b/src/pages/members.liquid
@@ -4,54 +4,25 @@ layout: page
 nav_hidden: true
 ---
 
-<div class="card-grid">
-  <a href="https://mcp.sjifire.org/dashboard" class="card card--link" target="_blank" rel="noopener">
-    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-    <h3>Incident Dashboard</h3>
-    <p>View real-time incident data.</p>
-  </a>
+<h2>Incident Management</h2>
+<ul>
+  <li><a href="https://mcp.sjifire.org/dashboard" target="_blank" rel="noopener">Incident Dashboard</a></li>
+  <li>Incident Reports &mdash; <a href="https://claude.ai" target="_blank" rel="noopener">Claude.ai</a> | <a href="FIXME">Setup</a> | <a href="FIXME">Hints &amp; Tricks</a></li>
+</ul>
 
-  <div class="card card--link">
-    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
-    <h3>Incident Reports</h3>
-    <p>
-      <a href="https://claude.ai" target="_blank" rel="noopener">Open Claude.ai</a> |
-      <a href="FIXME">Setup</a> |
-      <a href="FIXME">Hints &amp; Tricks</a>
-    </p>
-  </div>
+<h2>Communication</h2>
+<ul>
+  <li>Office 365 &mdash; <a href="https://outlook.office.com" target="_blank" rel="noopener">Outlook</a> | <a href="https://teams.microsoft.com" target="_blank" rel="noopener">Teams</a> | <a href="https://sjifires.sharepoint.com" target="_blank" rel="noopener">SharePoint</a></li>
+  <li><a href="https://secure17.aladtec.com/sjifire" target="_blank" rel="noopener">Aladtec</a> &mdash; Scheduling</li>
+  <li><a href="https://sjf3.ispyfire.com/me.html" target="_blank" rel="noopener">iSpyFire</a> &mdash; Dispatch alerting</li>
+</ul>
 
-  <div class="card card--link">
-    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-    <h3>Office 365</h3>
-    <p>
-      <a href="https://outlook.office.com" target="_blank" rel="noopener">Outlook</a> |
-      <a href="https://teams.microsoft.com" target="_blank" rel="noopener">Teams</a> |
-      <a href="https://sjifires.sharepoint.com" target="_blank" rel="noopener">SharePoint</a>
-    </p>
-  </div>
+<h2>Reference</h2>
+<ul>
+  <li><a href="https://app.lexipol.com/dashboard" target="_blank" rel="noopener">Lexipol</a> &mdash; Policies &amp; daily training</li>
+</ul>
 
-  <a href="https://secure17.aladtec.com/sjifire" class="card card--link" target="_blank" rel="noopener">
-    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-    <h3>Aladtec</h3>
-    <p>Scheduling and shift management.</p>
-  </a>
-
-  <a href="https://app.lexipol.com/dashboard" class="card card--link" target="_blank" rel="noopener">
-    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
-    <h3>Lexipol</h3>
-    <p>Policies and daily training bulletins.</p>
-  </a>
-
-  <a href="https://sjf3.ispyfire.com/me.html" class="card card--link" target="_blank" rel="noopener">
-    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
-    <h3>iSpyFire</h3>
-    <p>Mobile dispatch alerting.</p>
-  </a>
-
-  <a href="/admin/" class="card card--link" target="_blank" rel="noopener">
-    <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-    <h3>Website Admin</h3>
-    <p>Website content management. Requires additional admin permissions.</p>
-  </a>
-</div>
+<h2>Administration</h2>
+<ul>
+  <li><a href="/admin/" target="_blank" rel="noopener">Website Admin</a> &mdash; Requires additional permissions</li>
+</ul>


### PR DESCRIPTION
## Summary
- Redesign members portal from card grid to grouped link list with consistent two-line layout
- Each item shows: **Service Name** — Links, with a description on the second line
- Grouped under three sections with SVG icons: Incident Management, Communication, Misc
- Add **Aladtec** (Schedule | My Info), **Lexipol** (Dashboard), **iSpyFire** (Open)
- Replace single Office 365 link with **Outlook | Teams | SharePoint** sub-links
- Replace Incident Reports Claude AI link with **Internal | NERIS** links

## Test plan
- [x] `npm run dev` — verify all items render at `/members/`
- [x] All external links open in new tabs
- [x] Verify URLs resolve correctly: Aladtec, Lexipol, iSpyFire, NERIS, ops dashboard