### PR TITLE
Force account picker on AAD login

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -124,7 +124,7 @@
   "responseOverrides": {
     "401": {
       "statusCode": 302,
-      "redirect": "/.auth/login/aad?post_login_redirect_uri=/admin/"
+      "redirect": "/.auth/login/aad?post_login_redirect_uri=/admin/&prompt=select_account"
     }
   },
   "globalHeaders": {


### PR DESCRIPTION
## Summary
- Adds `prompt=select_account` to the 401→AAD login redirect so users signed into the wrong account (e.g. `svc-automations`) see the account picker instead of getting a cryptic AADSTS50105 error from Microsoft

## Test plan
- [ ] Sign into the browser with a non-assigned account, navigate to `/admin/` — should see account picker
- [ ] Sign in with the correct assigned account — should proceed to admin as before