### PR TITLE
Add Media Releases collection to TinaCMS

### DIFF
--- a/tina/config.ts
+++ b/tina/config.ts
@@ -775,6 +775,52 @@ export default defineConfig({
         ],
       },
       {
+        name: "mediaRelease",
+        label: "Media Releases",
+        path: "src/media_releases",
+        format: "json",
+        ui: {
+          filename: {
+            readonly: true,
+            slugify: (values: { date?: string; title?: string }) => {
+              const date = values?.date
+                ? new Date(values.date).toISOString().slice(0, 10)
+                : new Date().toISOString().slice(0, 10);
+              const title = values?.title || "untitled";
+              const slug = title
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, "-")
+                .replace(/^-|-$/g, "");
+              return `${date}-${slug}`;
+            },
+          },
+          itemProps: (item: { title?: string }) => ({
+            label: item?.title || "Untitled Release",
+          }),
+        },
+        fields: [
+          {
+            type: "datetime",
+            name: "date",
+            label: "Date",
+            required: true,
+          },
+          {
+            type: "string",
+            name: "title",
+            label: "Title",
+            isTitle: true,
+            required: true,
+          },
+          {
+            type: "image",
+            name: "document",
+            label: "PDF Document",
+            required: true,
+          },
+        ],
+      },
+      {
         name: "configNavigation",
         label: "Navigation",
         path: "src/_data",

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -704,6 +704,9 @@ export default defineConfig({
               return `${date}-${slug}`;
             },
           },
+          defaultItem: () => ({
+            date: new Date().toISOString(),
+          }),
           itemProps: (item: { title?: string; date?: string }) => ({
             label: item?.title || "Untitled Post",
           }),
@@ -794,6 +797,9 @@ export default defineConfig({
               return `${date}-${slug}`;
             },
           },
+          defaultItem: () => ({
+            date: new Date().toISOString(),
+          }),
           itemProps: (item: { title?: string }) => ({
             label: item?.title || "Untitled Release",
           }),

--- a/tina/media-store.ts
+++ b/tina/media-store.ts
@@ -13,6 +13,7 @@ export interface GitHubMediaStoreConfig {
  */
 export class GitHubMediaStore implements MediaStore {
   accept = "*";
+  parse = (media: Media): string => media.src;
   private apiBase: string;
 
   constructor(config: GitHubMediaStoreConfig = {}) {


### PR DESCRIPTION
## Summary
- Adds a `mediaRelease` collection to the TinaCMS config so admin users can create/edit media releases through the `/admin` UI
- Uses the same `YYYY-MM-DD-slug` filename pattern as news posts
- Fields: date, title, and PDF document upload (via TinaCMS image field which accepts any file type)
- Existing JSON files in `src/media_releases/` appear automatically in the admin sidebar

## Test plan
- [x] Run `npm run tina:dev` and confirm "Media Releases" appears in the admin sidebar
- [x] Verify existing releases are listed and editable
- [x] Create a new release with a PDF upload and confirm JSON file is created with correct naming
- [x] Verify the release appears on the public `/news/media-releases/` page