### PR TITLE
Enable search in TinaCMS admin UI

### DIFF
--- a/tina/config.ts
+++ b/tina/config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
     publicFolder: "_site",
   },
 
+  // Enable search in admin UI to suppress the "not configured" banner
+  search: { tina: {} },
+
   // Media config: local filesystem for dev, custom GitHub store for production
   media: isLocal
     ? {


### PR DESCRIPTION
## Summary
- Adds `search: { tina: {} }` to TinaCMS config to suppress the "You have not configured search" banner in the admin UI
- Replaces the warning with a functional search box for filtering collection items

## Test plan
- [ ] Run `npm run tina:dev` and verify search box appears instead of warning banner
- [ ] Test searching for a post by title