### PR TITLE
Revert TinaCMS search config that breaks build

### DIFF
--- a/tina/config.ts
+++ b/tina/config.ts
@@ -34,9 +34,6 @@ export default defineConfig({
     publicFolder: "_site",
   },
 
-  // Enable search in admin UI to suppress the "not configured" banner
-  search: { tina: {} },
-
   // Media config: local filesystem for dev, custom GitHub store for production
   media: isLocal
     ? {


### PR DESCRIPTION
## Summary
- Removes `search: { tina: {} }` from TinaCMS config added in #156
- This config requires a Tina Cloud `clientId` which is not available in our self-hosted setup
- Causes `tinacms build` to fail with `ERROR: clientId not configured`

## Test plan
- [x] Verify `tinacms build` no longer fails with clientId error
- [x] Confirm deploy workflow succeeds after merge