### PR TITLE
Use Entra ID Staff group for staff/volunteer classification

### DIFF
--- a/.github/workflows/sync-personnel.yml
+++ b/.github/workflows/sync-personnel.yml
@@ -90,6 +90,8 @@ jobs:
         run: npm ci
 
       - name: Sync personnel from Microsoft 365
+        env:
+          STAFF_GROUP_ID: c57e26ba-cab4-4185-afd2-61a47786229b
         run: |
           if [ "${{ inputs.force_refresh }}" = "true" ]; then
             node scripts/sync-personnel.mjs --force-refresh

--- a/scripts/sync-personnel.mjs
+++ b/scripts/sync-personnel.mjs
@@ -351,15 +351,14 @@ function computeCounts(personnel) {
     p.roles?.includes("Apparatus Operator") ||
     p.roles?.includes("Marine Crew");
 
-  // Full-time: FT Line Staff, Day Staff, or Administrative with FF role
-  const fullTimeTypes = ["FT Line Staff", "Day Staff", "Administrative"];
-  const fullTimeFirefighters = staff.filter(
-    p => fullTimeTypes.includes(p.staff_type) && hasFirefighterRole(p)
-  ).length;
-
   // Part-time: PT Line Staff with FF role
   const partTimeFirefighters = staff.filter(
     p => p.staff_type === "PT Line Staff" && hasFirefighterRole(p)
+  ).length;
+
+  // Full-time: all other staff with FF role (FT Line Staff, Day Staff, Administrative, Contractor, etc.)
+  const fullTimeFirefighters = staff.filter(
+    p => p.staff_type !== "PT Line Staff" && hasFirefighterRole(p)
   ).length;
 
   // Administrative: staff without FF role

--- a/scripts/sync-personnel.mjs
+++ b/scripts/sync-personnel.mjs
@@ -3,7 +3,8 @@
  * Sync personnel data from Microsoft 365
  *
  * Uses Entra ID user attributes:
- *   - employeeType: Determines staff vs volunteer (must be set to be included)
+ *   - Staff group membership: Determines staff vs volunteer
+ *   - employeeType: Must be set to be included (used for staff_type detail)
  *   - jobTitle: Display title
  *   - extensionAttribute1: Rank (Chief, Captain, Lieutenant, etc.)
  *   - extensionAttribute2: Apparatus Operator certification expiration date
@@ -42,13 +43,8 @@ const PHOTO_HASHES_PATH = join(PHOTOS_DIR, ".photo-hashes.json");
 const PHOTO_TRANSFORM = "w_1000,h_1000,c_fill,g_faces,q_auto";
 const DEFAULT_HASH_THRESHOLD = 10;
 
-// Employee types that map to "staff" (vs "volunteer")
-const STAFF_EMPLOYEE_TYPES = [
-  "Administrative",
-  "Day Staff",
-  "FT Line Staff",
-  "PT Line Staff",
-];
+// Entra ID group used to determine staff vs volunteer (set via STAFF_GROUP_ID env var)
+const STAFF_GROUP_ID = process.env.STAFF_GROUP_ID;
 
 // Ranks in sort order (Chief first)
 const RANKS = [
@@ -94,13 +90,11 @@ function normalizeFilename(firstName, lastName) {
 }
 
 /**
- * Determine employee category from employeeType attribute
+ * Fetch user IDs of the Staff group members
  */
-function determineEmployeeType(employeeType) {
-  if (!employeeType) return null;
-  if (STAFF_EMPLOYEE_TYPES.includes(employeeType)) return "staff";
-  if (employeeType === "Volunteer") return "volunteer";
-  return "volunteer"; // Unknown type defaults to volunteer
+async function fetchStaffGroupMembers(client) {
+  const response = await client.getGroupMembers(STAFF_GROUP_ID, ["id"]);
+  return new Set((response.value || []).map(m => m.id));
 }
 
 /**
@@ -451,11 +445,12 @@ async function main() {
 
   // Validate environment
   const { MS_GRAPH_TENANT_ID, MS_GRAPH_CLIENT_ID, MS_GRAPH_CLIENT_SECRET } = process.env;
-  if (!MS_GRAPH_TENANT_ID || !MS_GRAPH_CLIENT_ID || !MS_GRAPH_CLIENT_SECRET) {
+  if (!MS_GRAPH_TENANT_ID || !MS_GRAPH_CLIENT_ID || !MS_GRAPH_CLIENT_SECRET || !STAFF_GROUP_ID) {
     console.error("Missing required environment variables:");
     if (!MS_GRAPH_TENANT_ID) console.error("  - MS_GRAPH_TENANT_ID");
     if (!MS_GRAPH_CLIENT_ID) console.error("  - MS_GRAPH_CLIENT_ID");
     if (!MS_GRAPH_CLIENT_SECRET) console.error("  - MS_GRAPH_CLIENT_SECRET");
+    if (!STAFF_GROUP_ID) console.error("  - STAFF_GROUP_ID");
     process.exit(1);
   }
 
@@ -474,9 +469,12 @@ async function main() {
     clientSecret: MS_GRAPH_CLIENT_SECRET,
   });
 
-  console.log("\nFetching users from Microsoft 365...");
-  const users = await fetchUsersFromGraph(client);
-  console.log(`Found ${users.length} users`);
+  console.log("\nFetching users and staff group from Microsoft 365...");
+  const [users, staffMemberIds] = await Promise.all([
+    fetchUsersFromGraph(client),
+    fetchStaffGroupMembers(client),
+  ]);
+  console.log(`Found ${users.length} users, ${staffMemberIds.size} staff group members`);
 
   // Ensure directories exist
   await mkdir(PHOTOS_DIR, { recursive: true });
@@ -493,14 +491,15 @@ async function main() {
   for (const user of users) {
     if (!user.givenName || !user.surname) continue;
 
-    const employeeType = determineEmployeeType(user.employeeType);
-    if (!employeeType) {
+    if (!user.employeeType) {
       usersWithoutEmployeeType.push({
         name: `${user.givenName} ${user.surname}`,
         email: user.userPrincipalName,
       });
       continue;
     }
+
+    const employeeType = staffMemberIds.has(user.id) ? "staff" : "volunteer";
 
     const extAttrs = user.onPremisesExtensionAttributes || {};
     if (!extAttrs.extensionAttribute3?.trim()) {

--- a/src/_data/personnel.json
+++ b/src/_data/personnel.json
@@ -4,7 +4,7 @@
     "fullTimeFirefighters": 9,
     "partTimeFirefighters": 6,
     "administrativeStaff": 2,
-    "volunteerFirefighters": 32,
+    "volunteerFirefighters": 31,
     "volunteerSupport": 13
   },
   "personnel": [
@@ -134,6 +134,18 @@
       "employee_type": "staff",
       "staff_type": "Day Staff",
       "roles": [],
+      "photo": null
+    },
+    {
+      "first_name": "Irene",
+      "last_name": "Voskamp",
+      "rank": null,
+      "title": "Director of IT",
+      "employee_type": "staff",
+      "staff_type": "Contractor",
+      "roles": [
+        "Firefighter"
+      ],
       "photo": null
     },
     {
@@ -274,18 +286,6 @@
         "Marine Crew"
       ],
       "photo": "/assets/media/personnel_imgs/john_salinas.jpg"
-    },
-    {
-      "first_name": "Irene",
-      "last_name": "Voskamp",
-      "rank": null,
-      "title": "Director of IT",
-      "employee_type": "volunteer",
-      "staff_type": "Contractor",
-      "roles": [
-        "Firefighter"
-      ],
-      "photo": null
     },
     {
       "first_name": "John",

--- a/src/_data/personnel.json
+++ b/src/_data/personnel.json
@@ -1,10 +1,10 @@
 {
   "count": 62,
   "counts": {
-    "fullTimeFirefighters": 10,
+    "fullTimeFirefighters": 11,
     "partTimeFirefighters": 6,
     "administrativeStaff": 2,
-    "volunteerFirefighters": 31,
+    "volunteerFirefighters": 30,
     "volunteerSupport": 13
   },
   "personnel": [
@@ -20,6 +20,18 @@
         "Firefighter"
       ],
       "photo": "/assets/media/personnel_imgs/noel_monin.jpg"
+    },
+    {
+      "first_name": "Jordan",
+      "last_name": "Pollack",
+      "rank": "Division Chief",
+      "title": null,
+      "employee_type": "staff",
+      "staff_type": "Contractor",
+      "roles": [
+        "Firefighter"
+      ],
+      "photo": "/assets/media/personnel_imgs/jordan_pollack.jpg"
     },
     {
       "first_name": "Michael",
@@ -235,18 +247,6 @@
         "Firefighter"
       ],
       "photo": null
-    },
-    {
-      "first_name": "Jordan",
-      "last_name": "Pollack",
-      "rank": "Division Chief",
-      "title": null,
-      "employee_type": "volunteer",
-      "staff_type": "Contractor",
-      "roles": [
-        "Firefighter"
-      ],
-      "photo": "/assets/media/personnel_imgs/jordan_pollack.jpg"
     },
     {
       "first_name": "Erin",

--- a/src/_data/personnel.json
+++ b/src/_data/personnel.json
@@ -1,7 +1,7 @@
 {
   "count": 62,
   "counts": {
-    "fullTimeFirefighters": 9,
+    "fullTimeFirefighters": 10,
     "partTimeFirefighters": 6,
     "administrativeStaff": 2,
     "volunteerFirefighters": 31,
@@ -242,7 +242,7 @@
       "rank": "Division Chief",
       "title": null,
       "employee_type": "volunteer",
-      "staff_type": "Volunteer",
+      "staff_type": "Contractor",
       "roles": [
         "Firefighter"
       ],


### PR DESCRIPTION
## Summary
- Replaces hardcoded `employeeType` value matching with Entra ID **Staff group** membership to classify personnel as staff vs volunteer
- Fixes Voskamp (employeeType=Contractor) not appearing under Staff on the website
- `STAFF_GROUP_ID` passed as env var in the GitHub Actions workflow (and `.env` locally)

## Test plan
- [x] Ran `npm run sync-personnel` locally — Voskamp now shows as `employee_type: "staff"`, staff count = 18
- [x] Verify the sync-personnel workflow runs successfully after merge