### PR TITLE
Add rich-text editing for post lede field

### DIFF
--- a/tina/config.ts
+++ b/tina/config.ts
@@ -751,13 +751,19 @@ export default defineConfig({
             required: true,
           },
           {
-            type: "string",
+            type: "rich-text",
             name: "lede",
             label: "Lede (Summary)",
             description: "A brief summary shown in post listings",
-            ui: {
-              component: "textarea",
-            },
+            toolbarOverride: [
+              "bold",
+              "italic",
+              "underline",
+              "strikethrough",
+              "ul",
+              "ol",
+              "link",
+            ],
           },
           {
             type: "object",


### PR DESCRIPTION
## Summary
- Change the post lede/summary field from a plain textarea to a TinaCMS rich-text editor
- Limit the toolbar to styling (bold, italic, underline, strikethrough), lists, and links — images and embeds are intentionally excluded

## Test plan
- [x] Verify lede field in TinaCMS shows the limited rich-text toolbar
- [x] Verify image/embed options are not available in the lede editor
- [x] Verify existing post lede text renders correctly on the site
- [x] Run production build successfully