### PR TITLE
Update public documents link to non-expiring share URL

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,6 +1,6 @@
 {
   "prodUrl": "https://www.sjifire.org",
-  "publicDocumentsUrl": "https://sjifires.sharepoint.com/:f:/s/SJIFirePublicRecords/IgBbJPhsXp0iTLx2WataGf3dARGo93hz2540LD3Gmcu4LRk",
+  "publicDocumentsUrl": "https://sjifires.sharepoint.com/:f:/s/SJIFirePublicRecords/IgBbJPhsXp0iTLx2WataGf3dARGo93hz2540LD3Gmcu4LRk?e=qgTsB4",
   "cloudinaryFetchUrl": "https://www.sjifire.org",
   "corsAllowedOrigins": [
     "https://www.sjifire.org",

--- a/src/pages/contact.mdx
+++ b/src/pages/contact.mdx
@@ -32,7 +32,7 @@ If you have an emergency, **CALL 911**.
 
 ## Public Records
 
-Agendas, minutes, and board materials are available in our [Public Documents](https://sjifires.sharepoint.com/:f:/s/SJIFirePublicRecords/IgBbJPhsXp0iTLx2WataGf3dARGo93hz2540LD3Gmcu4LRk) reading room.
+Agendas, minutes, and board materials are available in our [Public Documents](https://sjifires.sharepoint.com/:f:/s/SJIFirePublicRecords/IgBbJPhsXp0iTLx2WataGf3dARGo93hz2540LD3Gmcu4LRk?e=qgTsB4) reading room.
 
 To request other public records, please submit a [Public Records Request form](/assets/media/docs/sjifr_records_request.pdf).
 

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -118,7 +118,7 @@
     },
     {
       "route": "/assets/docs/*",
-      "redirect": "https://sjifires.sharepoint.com/:f:/s/SJIFirePublicRecords/IgBbJPhsXp0iTLx2WataGf3dARGo93hz2540LD3Gmcu4LRk",
+      "redirect": "https://sjifires.sharepoint.com/:f:/s/SJIFirePublicRecords/IgBbJPhsXp0iTLx2WataGf3dARGo93hz2540LD3Gmcu4LRk?e=qgTsB4",
       "statusCode": 301
     }
   ],


### PR DESCRIPTION
## Summary

The public-documents SharePoint share link expired. This replaces it with the new never-expiring link (same share ID, now with the `?e=qgTsB4` parameter) in all three places it appears:

- `staticwebapp.config.json` — the `/assets/docs/*` redirect rule
- `src/_data/site.json` — the `publicDocumentsUrl` config value
- `src/pages/contact.mdx` — the "Public Documents" link on the contact page

## Verification

- Fetched the new link with no credentials (fresh cookie jar): it redeems anonymously — SharePoint issues a guest cookie, no sign-in page, and the page context reports `isAnonymousGuestUser: true`.
- It lands on the Reading Room library at the **Governance Documents** folder, matching the contact-page copy (agendas, minutes, board materials).
- "Never expires" can't be confirmed from outside SharePoint — please double-check the link settings under Manage access show no expiration.
- Both edited JSON files parse cleanly. Local build not run: `npm ci` fails on main because `package-lock.json` is out of sync with `package.json` (pre-existing, unrelated) — relying on the PR preview build.

## Notes

- `markdownlint` reports 3 pre-existing `MD013` line-length warnings in `contact.mdx`; left untouched since the repo has no markdownlint config and the URL line can't be shortened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)