### PR TITLE
Add live air quality & smoke row to Fire Safety widget

### DIFF
--- a/.github/workflows/update-air-quality.yml
+++ b/.github/workflows/update-air-quality.yml
@@ -1,0 +1,66 @@
+name: Update Air Quality from AirNow
+
+on:
+  schedule:
+    # Every 3 hours. AirNow updates hourly; the widget also links to the live
+    # Fire & Smoke Map for real-time conditions. Adjust cadence as needed.
+    - cron: '0 */3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-air-quality:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Validate required secret
+        run: |
+          if [ -z "${{ secrets.AIRNOW_API_KEY }}" ]; then
+            echo "::error::Missing AIRNOW_API_KEY secret. Get a free key at https://docs.airnowapi.org/"
+            exit 1
+          fi
+          echo "AIRNOW_API_KEY is present"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch current air quality
+        env:
+          AIRNOW_API_KEY: ${{ secrets.AIRNOW_API_KEY }}
+        run: npm run air-quality
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git add src/_data/air_quality.json
+          if git diff --cached --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            git diff --cached -- src/_data/air_quality.json >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Commit and push changes
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: update air quality data from AirNow
+
+          Auto-generated update of the current AQI for the Fire Safety widget."
+          git push

--- a/.github/workflows/update-air-quality.yml
+++ b/.github/workflows/update-air-quality.yml
@@ -2,9 +2,10 @@ name: Update Air Quality from AirNow
 
 on:
   schedule:
-    # Every 3 hours. AirNow updates hourly; the widget also links to the live
-    # Fire & Smoke Map for real-time conditions. Adjust cadence as needed.
-    - cron: '0 */3 * * *'
+    # Hourly (AirNow updates hourly). The fetch script only rewrites the data
+    # file — and thus redeploys the site — when the AQI moves >=5% or its
+    # category changes, so routine hourly runs are no-ops.
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ to the AirNow Fire & Smoke Map for live, hyperlocal smoke coverage.
 **Files:**
 - `scripts/generate-air-quality.mjs` - Fetches the nearest current AQI observation to Friday Harbor and writes `src/_data/air_quality.json`
 - `src/_includes/burn-status-widget.liquid` - Renders the "Air Quality & Smoke" row (color-coded by EPA AQI category; falls back to a "Check Air Quality" link when no reading is available)
-- `.github/workflows/update-air-quality.yml` - Scheduled workflow (every 3 hours)
+- `.github/workflows/update-air-quality.yml` - Scheduled workflow (hourly; only commits when the AQI moves ≥5% or its category changes)
 
 `air_quality.json` is auto-generated and is NOT edited via TinaCMS (unlike
 `burn_status.json`), so the sync never conflicts with manual edits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,31 @@ Personnel data and photos are synced daily from Microsoft 365 via Microsoft Grap
 npm run sync-personnel
 ```
 
+### Air Quality (AirNow)
+
+Current air quality / wildfire smoke conditions for the Fire Safety widget are
+pulled from AirNow (airnow.gov), the EPA's authoritative U.S. air quality source.
+San Juan Island has no permanent EPA monitor, so AirNow returns the nearest
+reporting station (often Anacortes); the widget shows that station name and links
+to the AirNow Fire & Smoke Map for live, hyperlocal smoke coverage.
+
+**Files:**
+- `scripts/generate-air-quality.mjs` - Fetches the nearest current AQI observation to Friday Harbor and writes `src/_data/air_quality.json`
+- `src/_includes/burn-status-widget.liquid` - Renders the "Air Quality & Smoke" row (color-coded by EPA AQI category; falls back to a "Check Air Quality" link when no reading is available)
+- `.github/workflows/update-air-quality.yml` - Scheduled workflow (every 3 hours)
+
+`air_quality.json` is auto-generated and is NOT edited via TinaCMS (unlike
+`burn_status.json`), so the sync never conflicts with manual edits.
+
+**Secrets:**
+- From GitHub Secrets: `AIRNOW_API_KEY` (free key from https://docs.airnowapi.org/), `DEPLOY_KEY` (SSH deploy key for pushing changes)
+
+**Local Testing:**
+```bash
+export AIRNOW_API_KEY="your-api-key"
+npm run air-quality
+```
+
 ## Azure Key Vault
 
 Most secrets are centralized in Azure Key Vault `gh-website-utilities`. GitHub Actions use OIDC to authenticate and fetch secrets at runtime. GitHub-specific secrets (like deploy keys) are stored in GitHub Secrets instead.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "scripts": {
     "stats": "node src/scripts/generate-stats.mjs",
+    "air-quality": "node scripts/generate-air-quality.mjs",
     "sync-personnel": "node scripts/sync-personnel.mjs",
     "cleanup-cloudinary": "node scripts/cleanup-cloudinary.mjs",
     "dev": "eleventy --serve --port=8080",

--- a/scripts/generate-air-quality.mjs
+++ b/scripts/generate-air-quality.mjs
@@ -23,7 +23,7 @@
  */
 
 import "dotenv/config";
-import { writeFile } from "node:fs/promises";
+import { writeFile, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -39,6 +39,11 @@ const LATITUDE = 48.5343;
 const LONGITUDE = -123.017;
 // Search radius (miles) — wide enough to reach the nearest reporting monitor
 const SEARCH_DISTANCE = 75;
+
+// Only rewrite the data file (which triggers a rebuild/deploy) when the AQI
+// moves by at least this fraction, or when the AQI category changes. Keeps
+// hourly runs from redeploying the site on trivial fluctuations.
+const CHANGE_THRESHOLD = 0.05;
 
 const API_KEY = process.env.AIRNOW_API_KEY;
 
@@ -60,6 +65,27 @@ async function fetchCurrentObservations() {
     throw new Error(`AirNow API returned ${res.status} ${res.statusText}`);
   }
   return res.json();
+}
+
+async function readExisting() {
+  try {
+    return JSON.parse(await readFile(OUTPUT_PATH, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether a new reading is worth writing (and thus redeploying the
+ * site). Always write on the first real reading or when the AQI category
+ * changes (a meaningful public-safety shift); otherwise only when the AQI
+ * moves by at least CHANGE_THRESHOLD relative to the last stored value.
+ */
+function isSignificantChange(oldData, next) {
+  if (!oldData || oldData.aqi == null) return true;
+  if (oldData.category !== next.category) return true;
+  if (oldData.aqi === 0) return next.aqi !== 0;
+  return Math.abs(next.aqi - oldData.aqi) / oldData.aqi >= CHANGE_THRESHOLD;
 }
 
 // ============================================================================
@@ -104,6 +130,15 @@ async function main() {
     updated: new Date().toISOString(),
     source_url: FIRE_AND_SMOKE_MAP_URL,
   };
+
+  const oldData = await readExisting();
+  if (!isSignificantChange(oldData, data)) {
+    console.log(
+      `Air quality unchanged (AQI ${data.aqi}, ${data.category}); ` +
+        `within ${CHANGE_THRESHOLD * 100}% of last value — leaving file unchanged.`,
+    );
+    return;
+  }
 
   await writeFile(OUTPUT_PATH, JSON.stringify(data, null, 2) + "\n");
   console.log(

--- a/scripts/generate-air-quality.mjs
+++ b/scripts/generate-air-quality.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Generate current air quality data from AirNow (EPA)
+ *
+ * Fetches the current observed Air Quality Index (AQI) for the nearest
+ * reporting monitor to Friday Harbor and writes src/_data/air_quality.json.
+ *
+ * AirNow (airnow.gov) is the authoritative U.S. air quality source, run by the
+ * EPA in partnership with NOAA, the WA Dept. of Ecology, and local agencies.
+ * PM2.5 is the pollutant that tracks wildfire smoke.
+ *
+ * NOTE: San Juan Island has no permanent EPA monitor, so AirNow returns the
+ * nearest reporting station (often Anacortes, ~20 mi away). The reporting area
+ * name is stored so the widget can be transparent about the source. For live,
+ * hyperlocal smoke coverage the widget also links to the AirNow Fire & Smoke
+ * Map, which blends official monitors with the county's PurpleAir sensors.
+ *
+ * Secrets (environment variables):
+ *   AIRNOW_API_KEY - Free API key from https://docs.airnowapi.org/
+ *
+ * CLI:
+ *   npm run air-quality
+ */
+
+import "dotenv/config";
+import { writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_PATH = join(__dirname, "..", "src", "_data", "air_quality.json");
+
+// Friday Harbor, San Juan Island
+const LATITUDE = 48.5343;
+const LONGITUDE = -123.017;
+// Search radius (miles) — wide enough to reach the nearest reporting monitor
+const SEARCH_DISTANCE = 75;
+
+const API_KEY = process.env.AIRNOW_API_KEY;
+
+// Live map centered on the San Juan Islands (smoke plume coverage + sensors)
+const FIRE_AND_SMOKE_MAP_URL = `https://fire.airnow.gov/#8/${LATITUDE}/${LONGITUDE}`;
+
+// ============================================================================
+// Fetch
+// ============================================================================
+
+async function fetchCurrentObservations() {
+  const url =
+    "https://www.airnowapi.org/aq/observation/latLong/current/" +
+    `?format=application/json&latitude=${LATITUDE}&longitude=${LONGITUDE}` +
+    `&distance=${SEARCH_DISTANCE}&API_KEY=${API_KEY}`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`AirNow API returned ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+  if (!API_KEY) {
+    console.error(
+      "::error::Missing AIRNOW_API_KEY. Get a free key at https://docs.airnowapi.org/",
+    );
+    process.exit(1);
+  }
+
+  let observations;
+  try {
+    observations = await fetchCurrentObservations();
+  } catch (err) {
+    // Don't clobber the last good reading on a transient API failure — the
+    // widget shows the previous value (with its timestamp) until the next run.
+    console.error(`::warning::Could not fetch AirNow data: ${err.message}`);
+    console.error("Leaving existing air_quality.json unchanged.");
+    return;
+  }
+
+  if (!Array.isArray(observations) || observations.length === 0) {
+    console.warn("No AirNow observations returned for the search area. Skipping.");
+    return;
+  }
+
+  // AirNow returns one entry per pollutant (O3, PM2.5, PM10). The headline AQI
+  // is the highest value across reported pollutants.
+  const primary = observations.reduce((worst, obs) =>
+    obs.AQI > worst.AQI ? obs : worst,
+  );
+
+  const data = {
+    aqi: primary.AQI,
+    category: primary.Category?.Name ?? null,
+    pollutant: primary.ParameterName ?? null,
+    reporting_area: primary.ReportingArea ?? null,
+    updated: new Date().toISOString(),
+    source_url: FIRE_AND_SMOKE_MAP_URL,
+  };
+
+  await writeFile(OUTPUT_PATH, JSON.stringify(data, null, 2) + "\n");
+  console.log(
+    `Air quality: AQI ${data.aqi} (${data.category}) — ${data.pollutant} via ${data.reporting_area}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(`::error::${err.message}`);
+  process.exit(1);
+});

--- a/src/_data/air_quality.json
+++ b/src/_data/air_quality.json
@@ -1,0 +1,8 @@
+{
+  "aqi": null,
+  "category": null,
+  "pollutant": null,
+  "reporting_area": null,
+  "updated": null,
+  "source_url": "https://fire.airnow.gov/#8/48.5343/-123.017"
+}

--- a/src/_includes/burn-status-widget.liquid
+++ b/src/_includes/burn-status-widget.liquid
@@ -21,13 +21,31 @@
     </tr>
     <tr class="even">
       <th>
+        Air Quality &amp; Smoke
+        {% if air_quality.reporting_area %}<aside>Nearest monitor: {{ air_quality.reporting_area }}{% if air_quality.pollutant %} &middot; {{ air_quality.pollutant }}{% endif %}</aside>{% endif %}
+      </th>
+      {% if air_quality.aqi %}
+        <td class="level level--aqi-{{ air_quality.category | slugify }}">
+          <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">
+            <span class="level__score">{{ air_quality.aqi }}</span>
+            <span class="level__label">AQI &middot; {{ air_quality.category }}</span>
+          </a>
+        </td>
+      {% else %}
+        <td>
+          <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">Fire &amp; Smoke Map &raquo;</a>
+        </td>
+      {% endif %}
+    </tr>
+    <tr class="odd">
+      <th>
         Residential Burn Permits
       </th>
       <td class="level level--{{ burn_status.burn_ban_status | slugify }}">
         {{ burn_status.burn_ban_status }}
       </td>
     </tr>
-    <tr class="odd">
+    <tr class="even">
       <th>
         Commercial Burn Permits
       </th>
@@ -35,7 +53,7 @@
         {{ burn_status.commercial_burn_ban_status }}
       </td>
     </tr>
-    <tr class="even">
+    <tr class="odd">
       <th>
         Recreational Fires: San Juan County
       </th>
@@ -43,7 +61,7 @@
         {{ burn_status.rec_campfire_status }}
       </td>
     </tr>
-    <tr class="odd">
+    <tr class="even">
       <th>
         Recreational Fires: State Park & DNR
       </th>
@@ -51,28 +69,13 @@
         {{ burn_status.state_campfire_status }}
       </td>
     </tr>
-    <tr class="even">
+    <tr class="odd">
       <th>
         Recreational Fires: National Parks
       </th>
       <td class="level level--{{ burn_status.np_campfire_status | slugify }}">
         {{ burn_status.np_campfire_status }}
       </td>
-    </tr>
-    <tr class="odd">
-      <th>
-        Air Quality &amp; Smoke
-        {% if air_quality.reporting_area %}<aside>Nearest monitor: {{ air_quality.reporting_area }}</aside>{% endif %}
-      </th>
-      {% if air_quality.aqi %}
-        <td class="level level--aqi-{{ air_quality.category | slugify }}">
-          <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">{{ air_quality.aqi }} &middot; {{ air_quality.category }}</a>
-        </td>
-      {% else %}
-        <td>
-          <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">Check Air Quality &raquo;</a>
-        </td>
-      {% endif %}
     </tr>
   </tbody>
   {% if page.url == '/' %}

--- a/src/_includes/burn-status-widget.liquid
+++ b/src/_includes/burn-status-widget.liquid
@@ -59,6 +59,21 @@
         {{ burn_status.np_campfire_status }}
       </td>
     </tr>
+    <tr class="odd">
+      <th>
+        Air Quality &amp; Smoke
+        {% if air_quality.reporting_area %}<aside>Nearest monitor: {{ air_quality.reporting_area }}</aside>{% endif %}
+      </th>
+      {% if air_quality.aqi %}
+        <td class="level level--aqi-{{ air_quality.category | slugify }}">
+          <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">{{ air_quality.aqi }} &middot; {{ air_quality.category }}</a>
+        </td>
+      {% else %}
+        <td>
+          <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">Check Air Quality &raquo;</a>
+        </td>
+      {% endif %}
+    </tr>
   </tbody>
   {% if page.url == '/' %}
     <tfoot class="widget__foot">

--- a/src/_includes/burn-status-widget.liquid
+++ b/src/_includes/burn-status-widget.liquid
@@ -22,7 +22,7 @@
     <tr class="even">
       <th>
         Air Quality &amp; Smoke
-        {% if air_quality.reporting_area %}<aside>Nearest monitor: {{ air_quality.reporting_area }}{% if air_quality.pollutant %} &middot; {{ air_quality.pollutant }}{% endif %}</aside>{% endif %}
+        {% if air_quality.reporting_area %}<aside>Nearest monitor: {{ air_quality.reporting_area }}{% if air_quality.pollutant %} <span class="widget__nowrap">&middot; {{ air_quality.pollutant }}</span>{% endif %}</aside>{% endif %}
       </th>
       {% if air_quality.aqi %}
         <td class="level level--aqi-{{ air_quality.category | slugify }}">

--- a/src/_includes/burn-status-widget.liquid
+++ b/src/_includes/burn-status-widget.liquid
@@ -11,7 +11,7 @@
     </div>
   </caption>
   <tbody class="widget__body">
-    <tr class="odd">
+    <tr>
       <th>
         Fire Danger
       </th>
@@ -19,25 +19,21 @@
         {{ burn_status.fire_status }}
       </td>
     </tr>
-    <tr class="even">
+    {% if air_quality.aqi %}
+    <tr>
       <th>
         Air Quality &amp; Smoke
         {% if air_quality.reporting_area %}<aside>Nearest monitor: {{ air_quality.reporting_area }}{% if air_quality.pollutant %} <span class="widget__nowrap">&middot; {{ air_quality.pollutant }}</span>{% endif %}</aside>{% endif %}
       </th>
-      {% if air_quality.aqi %}
-        <td class="level level--aqi-{{ air_quality.category | slugify }}">
-          <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">
-            <span class="level__score">{{ air_quality.aqi }}</span>
-            <span class="level__label">AQI &middot; {{ air_quality.category }}</span>
-          </a>
-        </td>
-      {% else %}
-        <td>
-          <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">Fire &amp; Smoke Map &raquo;</a>
-        </td>
-      {% endif %}
+      <td class="level level--aqi-{{ air_quality.category | slugify }}">
+        <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">
+          <span class="level__score">{{ air_quality.aqi }}</span>
+          <span class="level__label">AQI &middot; {{ air_quality.category }}</span>
+        </a>
+      </td>
     </tr>
-    <tr class="odd">
+    {% endif %}
+    <tr>
       <th>
         Residential Burn Permits
       </th>
@@ -45,7 +41,7 @@
         {{ burn_status.burn_ban_status }}
       </td>
     </tr>
-    <tr class="even">
+    <tr>
       <th>
         Commercial Burn Permits
       </th>
@@ -53,7 +49,7 @@
         {{ burn_status.commercial_burn_ban_status }}
       </td>
     </tr>
-    <tr class="odd">
+    <tr>
       <th>
         Recreational Fires: San Juan County
       </th>
@@ -61,7 +57,7 @@
         {{ burn_status.rec_campfire_status }}
       </td>
     </tr>
-    <tr class="even">
+    <tr>
       <th>
         Recreational Fires: State Park & DNR
       </th>
@@ -69,7 +65,7 @@
         {{ burn_status.state_campfire_status }}
       </td>
     </tr>
-    <tr class="odd">
+    <tr>
       <th>
         Recreational Fires: National Parks
       </th>

--- a/src/_includes/page.liquid
+++ b/src/_includes/page.liquid
@@ -17,7 +17,7 @@ layout: base
     <aside class="l-grid__sidebar">
       {% if include_burn_widget %}
         <div class="sidebar-block">
-          {% render "burn-status-widget.liquid", burn_status: burn_status, page: page %}
+          {% render "burn-status-widget.liquid", burn_status: burn_status, air_quality: air_quality, page: page %}
         </div>
       {% endif %}
       {% if include_incident_widget %}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1352,6 +1352,10 @@ body {
   text-decoration: underline;
 }
 
+.widget__nowrap {
+  white-space: nowrap;
+}
+
 .widget__body .level__score {
   display: block;
   font-size: 26px;

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1344,6 +1344,27 @@ body {
 
 .widget__body .level a {
   color: inherit;
+  text-decoration: none;
+}
+
+.widget__body .level a:hover .level__score,
+.widget__body .level a:focus .level__score {
+  text-decoration: underline;
+}
+
+.widget__body .level__score {
+  display: block;
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.widget__body .level__label {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
 }
 
 .widget__foot td {

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1311,6 +1311,41 @@ body {
   color: white;
 }
 
+/* EPA AQI categories (air quality / smoke) */
+.widget__body .level--aqi-good {
+  background-color: #cee8ce;
+  color: #206220;
+}
+
+.widget__body .level--aqi-moderate {
+  background-color: #fff3cd;
+  color: #856404;
+}
+
+.widget__body .level--aqi-unhealthy-for-sensitive-groups {
+  background-color: #ffe3c2;
+  color: #8a4b00;
+}
+
+.widget__body .level--aqi-unhealthy {
+  background-color: #ffe0e0;
+  color: var(--bright-red);
+}
+
+.widget__body .level--aqi-very-unhealthy {
+  background-color: #e7d5f0;
+  color: #6b2a86;
+}
+
+.widget__body .level--aqi-hazardous {
+  background-color: #4a0d18;
+  color: white;
+}
+
+.widget__body .level a {
+  color: inherit;
+}
+
 .widget__foot td {
   padding: 6px 15px;
   text-align: right;

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1248,6 +1248,12 @@ body {
   background-color: var(--lt-gray);
 }
 
+/* Burn-status widget stripes by position so conditionally-hidden rows
+   (e.g. Air Quality when there's no reading) never break the zebra. */
+.widget--burn-status .widget__body tr:nth-of-type(odd) {
+  background-color: var(--lt-gray);
+}
+
 .widget__body th,
 .widget__body td {
   border-bottom: 1px solid #d1d5d9;

--- a/src/pages/homepage.liquid
+++ b/src/pages/homepage.liquid
@@ -107,7 +107,7 @@ scripts: '<script src="/js/carousel.js" defer></script>'
 
   <aside class="l-grid__sidebar">
     <div class="sidebar-block">
-      {% render "burn-status-widget.liquid", burn_status: burn_status, page: page %}
+      {% render "burn-status-widget.liquid", burn_status: burn_status, air_quality: air_quality, page: page %}
     </div>
     <div class="sidebar-block">
       {% render "call-stats-widget.liquid", stats: stats, page: page %}


### PR DESCRIPTION
Pulls the current AQI for the nearest AirNow (EPA) monitor to Friday
Harbor into src/_data/air_quality.json via a scheduled workflow, and
renders it as a color-coded 'Air Quality & Smoke' row in the burn-status
widget. Links out to the AirNow Fire & Smoke Map for live, hyperlocal
smoke coverage, and shows the nearest reporting station since the island
has no permanent on-island monitor.

Degrades gracefully to a 'Check Air Quality' link when no reading is
available (e.g. before AIRNOW_API_KEY is configured).
