### PR TITLE
Read Fire Safety widget status live from the StationWorks API

### DIFF
--- a/.github/workflows/update-air-quality.yml
+++ b/.github/workflows/update-air-quality.yml
@@ -1,11 +1,10 @@
 name: Update Air Quality from AirNow
 
 on:
-  schedule:
-    # Hourly (AirNow updates hourly). The fetch script only rewrites the data
-    # file — and thus redeploys the site — when the AQI moves >=5% or its
-    # category changes, so routine hourly runs are no-ops.
-    - cron: '0 * * * *'
+  # No schedule. The Fire Safety widget reads air quality live from the
+  # StationWorks permits API at runtime, so nothing here needs to run on a
+  # timer. Kept manually runnable: this still refreshes src/_data/air_quality.json,
+  # which no longer feeds the site but is retained for now.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-air-quality.yml
+++ b/.github/workflows/update-air-quality.yml
@@ -62,5 +62,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "chore: update air quality data from AirNow
 
-          Auto-generated update of the current AQI for the Fire Safety widget."
+          Auto-generated update of the retained src/_data/air_quality.json snapshot.
+          The Fire Safety widget no longer reads this file -- it fetches air
+          quality live from the StationWorks API at runtime."
           git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,24 +138,57 @@ Personnel data and photos are synced daily from Microsoft 365 via Microsoft Grap
 npm run sync-personnel
 ```
 
-### Air Quality (AirNow)
+### Fire Safety Widget (Burn Status + Air Quality)
 
-Current air quality / wildfire smoke conditions for the Fire Safety widget are
-pulled from AirNow (airnow.gov), the EPA's authoritative U.S. air quality source.
-San Juan Island has no permanent EPA monitor, so AirNow returns the nearest
-reporting station (often Anacortes); the widget shows that station name and links
-to the AirNow Fire & Smoke Map for live, hyperlocal smoke coverage.
+The Fire Safety widget reads **live at runtime** from the StationWorks permits
+API. Nothing about it is baked in at build time.
+
+**Endpoint:** `https://api.permits.stationworks.app/v1/agencies/sjifire/status`
+(CORS-open, no API key, `cache-control: max-age=120`)
+
+One response supplies the whole widget: burn season, fire danger, all five
+permit/recreational statuses, and air quality.
 
 **Files:**
-- `scripts/generate-air-quality.mjs` - Fetches the nearest current AQI observation to Friday Harbor and writes `src/_data/air_quality.json`
-- `src/_includes/burn-status-widget.liquid` - Renders the "Air Quality & Smoke" row (color-coded by EPA AQI category; falls back to a "Check Air Quality" link when no reading is available)
-- `.github/workflows/update-air-quality.yml` - Scheduled workflow (hourly; only commits when the AQI moves ≥5% or its category changes)
+- `src/_includes/burn-status-widget.liquid` - renders structure only (row labels,
+  placeholder cells, `data-*` hooks). Contains no data references.
+- `src/js/burn-status.js` - fetches on every page load and patches the cells.
+  Maps the entire payload before touching the DOM, so the widget is never
+  half-patched.
 
-`air_quality.json` is auto-generated and is NOT edited via TinaCMS (unlike
-`burn_status.json`), so the sync never conflicts with manual edits.
+**There is no static fallback, deliberately.** If the API is unreachable the
+widget shows "Live fire status unavailable" with the office phone number. A
+stale committed baseline would instead show a confident wrong answer about
+burn permits, which is worse than admitting we don't know.
 
-**Secrets:**
-- From GitHub Secrets: `AIRNOW_API_KEY` (free key from https://docs.airnowapi.org/), `DEPLOY_KEY` (SSH deploy key for pushing changes)
+**Enums** (confirmed with StationWorks):
+- `fireDanger`: `low`, `moderate`, `high`, `very_high`, `extreme`
+- `state`: `open`, `closed`, `restricted` - valid on **every** status row,
+  including residential and commercial permits
+
+Tokens are snake_case; the widget title-cases them for display (`very_high` ->
+"Very High") and slugifies them for the CSS class (`level--very-high`). One
+exception: `airQuality.category` arrives display-ready and is **never**
+title-cased, or EPA's "Unhealthy for Sensitive Groups" would render as
+"Unhealthy For Sensitive Groups".
+
+#### Deprecated: TinaCMS "Burn Status" and the AirNow pipeline
+
+`src/_data/burn_status.json` and `src/_data/air_quality.json` are **no longer read
+by the site.** They remain on disk, and the TinaCMS collection is still present
+but labelled `Burn Status (DEPRECATED — DO NOT EDIT)`.
+
+**Editing burn status in TinaCMS has no effect on the public site and produces no
+error.** Burn status is changed in the StationWorks permits system. Deleting the
+collection and both JSON files is a pending follow-up.
+
+`.github/workflows/update-air-quality.yml` and `scripts/generate-air-quality.mjs`
+are retained and manually runnable (`workflow_dispatch`), but **no longer run on a
+schedule**. The hourly cron produced 214 commits in 16 days -- roughly 13 site
+redeploys a day -- to maintain a number the browser now fetches directly.
+
+**Secrets** (only needed for a manual run):
+- From GitHub Secrets: `AIRNOW_API_KEY`, `DEPLOY_KEY`
 
 **Local Testing:**
 ```bash

--- a/docs/superpowers/plans/2026-08-09-burn-status-from-api.md
+++ b/docs/superpowers/plans/2026-08-09-burn-status-from-api.md
@@ -1,0 +1,1232 @@
+# Runtime Burn Status from the StationWorks API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the Fire Safety widget entirely from a live client-side fetch of the StationWorks permits API, replacing two committed data files, and stop the hourly AirNow workflow that redeploys the site ~13× a day.
+
+**Architecture:** Eleventy renders the widget's structure only — row labels, placeholder cells, `aria-busy="true"`. A plain browser IIFE at `src/js/burn-status.js` fetches `https://api.permits.stationworks.app/v1/agencies/sjifire/status` on every page load, maps the payload to a view model, and patches every cell in one pass. Any failure replaces the table body with a warning. There is no static fallback and no `localStorage` — the response's `cache-control: max-age=120` does the throttling.
+
+**Tech Stack:** Eleventy 3 + LiquidJS · vanilla browser JS (no build step, no modules) · `node --test` + jsdom 28 for unit tests · Playwright 1.57 for e2e · Azure Static Web Apps CSP.
+
+**Spec:** `docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md`
+
+## Global Constraints
+
+- **Worktree:** `.claude/worktrees/burn-status-from-api`, branch `feat/burn-status-from-api`. All paths below are relative to it.
+- **`src/js/burn-status.js` is a plain browser IIFE.** No ESM, no bundler, no dependencies. 2-space indent, `'use strict'`, early-return guard — match `src/js/carousel.js`.
+- **Unit tests are CommonJS** (`require`). `package.json` has no `"type"` field, so `.js` is CJS. Match `tests/carousel.test.js`.
+- **Endpoint:** `https://api.permits.stationworks.app/v1/agencies/sjifire/status`
+- **`fireDanger` enum (confirmed):** `low`, `moderate`, `high`, `very_high`, `extreme`
+- **`state` enum (confirmed):** `open`, `closed`, `restricted` — valid on **every** status row including permits.
+- **Status slugs consumed:** `residential`, `commercial`, `recreational-county`, `recreational-dnr`, `recreational-nps`
+- **Two transforms, never confused:** `slugify` (→ CSS class suffix) and `titleCase` (→ display text). Both split on whitespace, underscore, and hyphen.
+- **`airQuality.category` is NEVER title-cased.** It arrives display-ready. Title-casing would turn EPA's `"Unhealthy for Sensitive Groups"` into `"Unhealthy For Sensitive Groups"`.
+- **Office phone:** `(360) 378-5334`, linked as `tel:(360) 378-5334` (matches `src/_includes/footer.liquid:47`).
+- **Burn permits page:** `/services/burn-permits/`
+- **No new `level--*` colors.** All eight already exist at `src/css/site.css:1296-1349`.
+- **`src/js/` is not in the `lint:js` glob.** Do not add it — out of scope.
+- Run `npm run lint` and `npm run test:unit` before every commit.
+
+## Already on the branch
+
+The TinaCMS deprecation notice (spec § `tina/config.ts`) was committed in `69319a0`. Do not redo it. Verify with `git show 69319a0 -- tina/config.ts` if unsure.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/_includes/burn-status-widget.liquid` | **Modify.** Static structure + hooks only. No data references. |
+| `src/js/burn-status.js` | **Create.** Fetch, map, patch, fail. The only file with behavior. |
+| `src/css/site.css` | **Modify.** Two additions: `.level--unknown`, `.widget__warning`. |
+| `src/_includes/page.liquid:20` | **Modify.** Drop unused render args. |
+| `src/pages/homepage.liquid:110` | **Modify.** Drop unused render args. |
+| `staticwebapp.config.json:136` | **Modify.** One host onto `connect-src`. |
+| `.github/workflows/update-air-quality.yml` | **Modify.** Remove `schedule:`. |
+| `CLAUDE.md` | **Modify.** Document the new data flow. |
+| `tests/burn-status.test.js` | **Create.** jsdom unit tests. |
+| `tests/fixtures/agency-status.json` | **Create.** Captured live response. |
+| `tests/burn-status.spec.js` | **Create.** Playwright e2e, route-mocked. |
+
+**Untouched:** `src/_data/burn_status.json`, `src/_data/air_quality.json`, `scripts/generate-air-quality.mjs`.
+
+## The DOM contract
+
+Task 1 creates this markup; Task 2 onward patches it. **The selectors are the interface between them — do not rename without updating both.**
+
+| Selector | Purpose |
+|---|---|
+| `[data-burn-status]` | The `<table>`. Script's mount point and early-return guard. |
+| `[data-burn-body]` | The `<tbody>`. Replaced wholesale on failure. |
+| `[data-burn-season]` | Header season line. Starts `hidden`. |
+| `[data-season-range]` | `<span>` inside it holding `Oct 6-Jun 5`. |
+| `[data-row="fire-danger"]` | Fire danger `<td>`. |
+| `[data-row="residential"]` etc. | One per status slug — the attribute value **is** the API slug. |
+| `[data-aqi-row]` | Air-quality `<tr>`. Starts `hidden`. |
+| `[data-row="air-quality"]` | Air-quality `<td>` (carries the `level--aqi-*` class). |
+| `[data-aqi-link]` / `[data-aqi-score]` / `[data-aqi-label]` / `[data-aqi-source]` | Inner nodes. |
+
+---
+
+### Task 1: Server-rendered skeleton, CSS, and CSP
+
+**Files:**
+- Modify: `src/_includes/burn-status-widget.liquid` (full rewrite, 84 lines → skeleton)
+- Modify: `src/css/site.css` (append after line 1349, before `.widget__body .level a`)
+- Modify: `src/_includes/page.liquid:20`
+- Modify: `src/pages/homepage.liquid:110`
+- Modify: `staticwebapp.config.json:136`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the DOM contract above, consumed by every later task.
+
+- [ ] **Step 1: Replace the widget template**
+
+Overwrite `src/_includes/burn-status-widget.liquid` entirely:
+
+```liquid
+<table class="widget widget--burn-status" data-burn-status aria-busy="true">
+  <caption class="widget__header">
+    <div class="flex">
+      <svg aria-hidden="true"><use xlink:href='#flame' /></svg>
+      <div>
+        <span class="widget__title">Fire Safety</span>
+        <div class="timeframe" data-burn-season hidden>
+          Burn Season: <span data-season-range></span>
+        </div>
+      </div>
+    </div>
+  </caption>
+  <tbody class="widget__body" data-burn-body>
+    <tr>
+      <th>
+        Fire Danger
+      </th>
+      <td class="level level--unknown" data-row="fire-danger">&mdash;</td>
+    </tr>
+    <tr data-aqi-row hidden>
+      <th>
+        Air Quality &amp; Smoke
+        <aside data-aqi-source></aside>
+      </th>
+      <td class="level" data-row="air-quality">
+        <a href="#" target="_blank" rel="noopener" data-aqi-link>
+          <span class="level__score" data-aqi-score></span>
+          <span class="level__label" data-aqi-label></span>
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <th>
+        Residential Burn Permits
+      </th>
+      <td class="level level--unknown" data-row="residential">&mdash;</td>
+    </tr>
+    <tr>
+      <th>
+        Commercial Burn Permits
+      </th>
+      <td class="level level--unknown" data-row="commercial">&mdash;</td>
+    </tr>
+    <tr>
+      <th>
+        Recreational Fires: San Juan County
+      </th>
+      <td class="level level--unknown" data-row="recreational-county">&mdash;</td>
+    </tr>
+    <tr>
+      <th>
+        Recreational Fires: State Park & DNR
+      </th>
+      <td class="level level--unknown" data-row="recreational-dnr">&mdash;</td>
+    </tr>
+    <tr>
+      <th>
+        Recreational Fires: National Parks
+      </th>
+      <td class="level level--unknown" data-row="recreational-nps">&mdash;</td>
+    </tr>
+  </tbody>
+  {% if page.url == '/' %}
+    <tfoot class="widget__foot">
+      <td colspan="2">
+        <a href="/services/burn-permits/">More Info »</a>
+      </td>
+    </tfoot>
+  {% endif %}
+</table>
+<script defer src="/js/burn-status.js"></script>
+```
+
+Note: no `{{ burn_status.* }}` or `{{ air_quality.* }}` references remain anywhere in the file.
+
+- [ ] **Step 2: Add the two CSS rules**
+
+In `src/css/site.css`, immediately after the `.widget__body .level--aqi-hazardous` block (ends line 1349) and before `.widget__body .level a`:
+
+```css
+/* Placeholder shown before the live fetch resolves */
+.widget__body .level--unknown {
+  background-color: #f0f0f0;
+  color: #6b6b6b;
+  font-weight: 400;
+}
+
+/* Shown when the live status API is unreachable */
+.widget__body .widget__warning {
+  padding: 15px 5px;
+  font-size: 0.9em;
+  line-height: 1.4;
+  color: #6b6b6b;
+}
+
+.widget__body .widget__warning a {
+  color: inherit;
+  text-decoration: underline;
+}
+```
+
+- [ ] **Step 3: Drop the unused render arguments**
+
+`src/_includes/page.liquid:20` — change:
+
+```liquid
+          {% render "burn-status-widget.liquid", burn_status: burn_status, air_quality: air_quality, page: page %}
+```
+
+to:
+
+```liquid
+          {% render "burn-status-widget.liquid", page: page %}
+```
+
+`src/pages/homepage.liquid:110` — change:
+
+```liquid
+      {% render "burn-status-widget.liquid", burn_status: burn_status, air_quality: air_quality, page: page %}
+```
+
+to:
+
+```liquid
+      {% render "burn-status-widget.liquid", page: page %}
+```
+
+- [ ] **Step 4: Widen the CSP by one host**
+
+In `staticwebapp.config.json:136`, inside the `Content-Security-Policy` value, change:
+
+```
+connect-src 'self' https://res.cloudinary.com https://api.cloudinary.com https://content.cloudinary.com;
+```
+
+to:
+
+```
+connect-src 'self' https://res.cloudinary.com https://api.cloudinary.com https://content.cloudinary.com https://api.permits.stationworks.app;
+```
+
+Change nothing else in that header.
+
+- [ ] **Step 5: Verify the build and the rendered markup**
+
+Run:
+
+```bash
+npm run build
+grep -c 'data-burn-status' _site/index.html
+grep -c 'burn_status' _site/index.html
+```
+
+Expected: first `grep` prints `1`; second prints `0` (no leftover template data). The build must exit 0.
+
+- [ ] **Step 6: Lint**
+
+Run: `npm run lint`
+Expected: exits 0. (`lint:css` covers `src/css/**/*.css`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/_includes/burn-status-widget.liquid src/css/site.css \
+        src/_includes/page.liquid src/pages/homepage.liquid staticwebapp.config.json
+git commit -m "feat: render Fire Safety widget as a static skeleton
+
+Strips all burn_status and air_quality data references from the widget,
+leaving row labels, placeholder cells and stable data-* hooks for the
+client-side script to patch. Adds .level--unknown and .widget__warning
+styles, and allows api.permits.stationworks.app in connect-src.
+
+The widget shows placeholders until the next task adds the fetch."
+```
+
+---
+
+### Task 2: Fetch and patch the happy path
+
+**Files:**
+- Create: `src/js/burn-status.js`
+- Create: `tests/fixtures/agency-status.json`
+- Create: `tests/burn-status.test.js`
+
+**Interfaces:**
+- Consumes: the DOM contract from Task 1.
+- Produces:
+  - `window.__burnStatusReady` — a `Promise` that settles after the widget has been patched or the warning rendered. **Tests await this**; without it they race the fetch. It is the script's only global.
+  - Internal helpers `slugify(value) -> string`, `titleCase(value) -> string`, `buildView(payload) -> object|null`, `render(view) -> void`, `renderWarning() -> void`. Not exported; tested through the DOM.
+
+- [ ] **Step 1: Save the fixture**
+
+Create `tests/fixtures/agency-status.json` — the live response captured 2026-08-09:
+
+```json
+{
+  "agency": { "slug": "sjifire", "displayName": "San Juan Island Fire & Rescue" },
+  "season": { "start": "2026-10-06", "end": "2027-06-05" },
+  "fireDanger": "high",
+  "statuses": [
+    { "slug": "residential", "label": "Residential Burn Permits", "state": "closed", "permitTypeSlug": "residential", "linkUrl": null, "section": null },
+    { "slug": "commercial", "label": "Commercial Burn Permits", "state": "closed", "permitTypeSlug": "commercial", "linkUrl": null, "section": null },
+    { "slug": "recreational-county", "label": "County lands", "state": "open", "permitTypeSlug": null, "linkUrl": null, "section": "recreational-fires" },
+    { "slug": "recreational-dnr", "label": "State Park & DNR lands", "state": "closed", "permitTypeSlug": null, "linkUrl": null, "section": "recreational-fires" },
+    { "slug": "recreational-nps", "label": "National Park lands", "state": "closed", "permitTypeSlug": null, "linkUrl": null, "section": "recreational-fires" }
+  ],
+  "airQuality": {
+    "station": "Anacortes",
+    "pm25Aqi": 17,
+    "category": "Good",
+    "categoryNumber": 1,
+    "observedAt": "2026-08-09T17:00:00.000Z",
+    "linkUrl": "https://www.airnow.gov/?reportingArea=Anacortes&stateCode=WA"
+  },
+  "asOf": "2026-08-09T17:35:39.339Z"
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/burn-status.test.js`:
+
+```js
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const { JSDOM } = require("jsdom");
+const fs = require("fs");
+const path = require("path");
+
+const script = fs.readFileSync(
+  path.join(__dirname, "../src/js/burn-status.js"),
+  "utf-8"
+);
+
+const fixture = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "fixtures/agency-status.json"), "utf-8")
+);
+
+const WIDGET_HTML = `<!DOCTYPE html><html><body>
+  <table class="widget widget--burn-status" data-burn-status aria-busy="true">
+    <caption class="widget__header">
+      <div class="timeframe" data-burn-season hidden>
+        Burn Season: <span data-season-range></span>
+      </div>
+    </caption>
+    <tbody class="widget__body" data-burn-body>
+      <tr><th>Fire Danger</th>
+        <td class="level level--unknown" data-row="fire-danger">&mdash;</td></tr>
+      <tr data-aqi-row hidden>
+        <th>Air Quality &amp; Smoke <aside data-aqi-source></aside></th>
+        <td class="level" data-row="air-quality">
+          <a href="#" target="_blank" rel="noopener" data-aqi-link>
+            <span class="level__score" data-aqi-score></span>
+            <span class="level__label" data-aqi-label></span>
+          </a></td></tr>
+      <tr><th>Residential Burn Permits</th>
+        <td class="level level--unknown" data-row="residential">&mdash;</td></tr>
+      <tr><th>Commercial Burn Permits</th>
+        <td class="level level--unknown" data-row="commercial">&mdash;</td></tr>
+      <tr><th>Recreational Fires: San Juan County</th>
+        <td class="level level--unknown" data-row="recreational-county">&mdash;</td></tr>
+      <tr><th>Recreational Fires: State Park &amp; DNR</th>
+        <td class="level level--unknown" data-row="recreational-dnr">&mdash;</td></tr>
+      <tr><th>Recreational Fires: National Parks</th>
+        <td class="level level--unknown" data-row="recreational-nps">&mdash;</td></tr>
+    </tbody>
+  </table>
+</body></html>`;
+
+/**
+ * Boots the widget in a fresh JSDOM with a stubbed fetch, then waits for the
+ * script to finish patching. `responder` receives no args and returns whatever
+ * the stubbed fetch should resolve/reject with.
+ */
+async function boot(responder) {
+  const dom = new JSDOM(WIDGET_HTML, { runScripts: "dangerously" });
+  dom.window.fetch = () => responder();
+  const el = dom.window.document.createElement("script");
+  el.textContent = script;
+  dom.window.document.body.appendChild(el);
+  await dom.window.__burnStatusReady;
+  return dom.window.document;
+}
+
+/** A fetch stub that resolves with `body` as JSON and HTTP 200. */
+function ok(body) {
+  return () => Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  });
+}
+
+const cell = (doc, row) => doc.querySelector(`[data-row="${row}"]`);
+
+describe("Burn status widget", () => {
+  it("patches every status row from the API payload", async () => {
+    const doc = await boot(ok(fixture));
+
+    assert.strictEqual(cell(doc, "fire-danger").textContent.trim(), "High");
+    assert.ok(cell(doc, "fire-danger").className.includes("level--high"));
+
+    assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
+    assert.ok(cell(doc, "residential").className.includes("level--closed"));
+
+    assert.strictEqual(cell(doc, "commercial").textContent.trim(), "Closed");
+    assert.strictEqual(cell(doc, "recreational-county").textContent.trim(), "Open");
+    assert.ok(cell(doc, "recreational-county").className.includes("level--open"));
+    assert.strictEqual(cell(doc, "recreational-dnr").textContent.trim(), "Closed");
+    assert.strictEqual(cell(doc, "recreational-nps").textContent.trim(), "Closed");
+  });
+
+  it("renders the burn season in UTC, not local time", async () => {
+    const doc = await boot(ok(fixture));
+    const season = doc.querySelector("[data-burn-season]");
+    assert.strictEqual(season.hidden, false);
+    // 2026-10-06 / 2027-06-05 -- must not slip to Oct 5 / Jun 4 in Pacific time
+    assert.strictEqual(
+      doc.querySelector("[data-season-range]").textContent.trim(),
+      "Oct 6-Jun 5"
+    );
+  });
+
+  it("fills and reveals the air quality row", async () => {
+    const doc = await boot(ok(fixture));
+    const row = doc.querySelector("[data-aqi-row]");
+    assert.strictEqual(row.hidden, false);
+    assert.strictEqual(doc.querySelector("[data-aqi-score]").textContent, "17");
+    assert.strictEqual(
+      doc.querySelector("[data-aqi-label]").textContent,
+      "AQI · Good"
+    );
+    assert.ok(
+      cell(doc, "air-quality").className.includes("level--aqi-good")
+    );
+    assert.strictEqual(
+      doc.querySelector("[data-aqi-link]").getAttribute("href"),
+      "https://www.airnow.gov/?reportingArea=Anacortes&stateCode=WA"
+    );
+    assert.match(
+      doc.querySelector("[data-aqi-source]").textContent,
+      /Nearest monitor: Anacortes/
+    );
+  });
+
+  it("clears aria-busy once patched", async () => {
+    const doc = await boot(ok(fixture));
+    assert.strictEqual(
+      doc.querySelector("[data-burn-status]").hasAttribute("aria-busy"),
+      false
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `node --test tests/burn-status.test.js`
+Expected: FAIL — `ENOENT ... src/js/burn-status.js`, because the script does not exist yet.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/js/burn-status.js`:
+
+```js
+// Fire Safety widget -- live burn status from the StationWorks permits API.
+// The server renders structure only; everything below fills it in.
+(function () {
+  'use strict';
+
+  const table = document.querySelector('[data-burn-status]');
+  if (!table) return;
+
+  const ENDPOINT = 'https://api.permits.stationworks.app/v1/agencies/sjifire/status';
+  const TIMEOUT_MS = 8000;
+
+  // The data-row attribute for these rows IS the API's status slug.
+  const STATUS_SLUGS = [
+    'residential',
+    'commercial',
+    'recreational-county',
+    'recreational-dnr',
+    'recreational-nps'
+  ];
+
+  // Tokens we have a colour for. Anything else renders uncoloured rather than
+  // mis-coloured -- a wrong colour on a fire danger row is worse than none.
+  const KNOWN_LEVELS = [
+    'low', 'moderate', 'high', 'very-high', 'extreme',
+    'open', 'closed', 'restricted'
+  ];
+
+  const SEASON_FMT = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC'
+  });
+
+  // "very_high" -> "very-high" (CSS class suffix)
+  function slugify(value) {
+    return String(value).trim().toLowerCase().replace(/[\s_-]+/g, '-');
+  }
+
+  // "very_high" -> "Very High" (display text)
+  function titleCase(value) {
+    return String(value)
+      .trim()
+      .toLowerCase()
+      .split(/[\s_-]+/)
+      .filter(Boolean)
+      .map(function (word) {
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      })
+      .join(' ');
+  }
+
+  function formatSeasonDate(value) {
+    if (typeof value !== 'string') return null;
+    const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (!match) return null;
+    // Force UTC -- naive parsing renders 2026-10-06 as Oct 5 in Pacific time.
+    const date = new Date(match[1] + 'T00:00:00Z');
+    return isNaN(date.getTime()) ? null : SEASON_FMT.format(date);
+  }
+
+  function cellFor(token) {
+    if (typeof token !== 'string' || !token.trim()) {
+      return { text: '—', className: 'level level--unknown' };
+    }
+    const slug = slugify(token);
+    return {
+      text: titleCase(token),
+      className: KNOWN_LEVELS.indexOf(slug) === -1
+        ? 'level'
+        : 'level level--' + slug
+    };
+  }
+
+  function seasonFor(season) {
+    if (!season) return null;
+    const start = formatSeasonDate(season.start);
+    const end = formatSeasonDate(season.end);
+    return start && end ? start + '-' + end : null;
+  }
+
+  function airQualityFor(aq) {
+    if (!aq) return null;
+    const aqi = aq.pm25Aqi;
+    if (typeof aqi !== 'number' || !isFinite(aqi) || aqi < 0) return null;
+    // category arrives display-ready ("Unhealthy for Sensitive Groups").
+    // Slugify it for the class, but never title-case it for display.
+    const category = typeof aq.category === 'string' ? aq.category : '';
+    return {
+      score: String(Math.round(aqi)),
+      label: category ? 'AQI · ' + category : 'AQI',
+      className: category ? 'level level--aqi-' + slugify(category) : 'level',
+      station: typeof aq.station === 'string' ? aq.station : '',
+      href: typeof aq.linkUrl === 'string' && aq.linkUrl ? aq.linkUrl : null
+    };
+  }
+
+  // Map the whole payload up front. Returning null means "show the warning" --
+  // we never patch a partial view.
+  function buildView(payload) {
+    if (!payload || !Array.isArray(payload.statuses) || !payload.statuses.length) {
+      return null;
+    }
+
+    const bySlug = Object.create(null);
+    payload.statuses.forEach(function (status) {
+      if (status && typeof status.slug === 'string') bySlug[status.slug] = status;
+    });
+
+    const rows = { 'fire-danger': cellFor(payload.fireDanger) };
+    STATUS_SLUGS.forEach(function (slug) {
+      rows[slug] = cellFor(bySlug[slug] && bySlug[slug].state);
+    });
+
+    return {
+      rows: rows,
+      season: seasonFor(payload.season),
+      airQuality: airQualityFor(payload.airQuality)
+    };
+  }
+
+  function renderAirQuality(aq) {
+    const row = table.querySelector('[data-aqi-row]');
+    if (!row) return;
+    if (!aq) {
+      row.hidden = true;
+      return;
+    }
+
+    const cell = table.querySelector('[data-row="air-quality"]');
+    if (cell) cell.className = aq.className;
+
+    const score = table.querySelector('[data-aqi-score]');
+    if (score) score.textContent = aq.score;
+
+    const label = table.querySelector('[data-aqi-label]');
+    if (label) label.textContent = aq.label;
+
+    const link = table.querySelector('[data-aqi-link]');
+    if (link && aq.href) link.setAttribute('href', aq.href);
+
+    const source = table.querySelector('[data-aqi-source]');
+    if (source) {
+      source.textContent = '';
+      if (aq.station) {
+        source.appendChild(
+          document.createTextNode('Nearest monitor: ' + aq.station + ' ')
+        );
+        const nowrap = document.createElement('span');
+        nowrap.className = 'widget__nowrap';
+        nowrap.textContent = '· PM2.5';
+        source.appendChild(nowrap);
+      }
+    }
+
+    row.hidden = false;
+  }
+
+  function render(view) {
+    Object.keys(view.rows).forEach(function (key) {
+      const cell = table.querySelector('[data-row="' + key + '"]');
+      if (!cell) return;
+      cell.textContent = view.rows[key].text;
+      cell.className = view.rows[key].className;
+    });
+
+    const season = table.querySelector('[data-burn-season]');
+    const range = table.querySelector('[data-season-range]');
+    if (season && range) {
+      if (view.season) {
+        range.textContent = view.season;
+        season.hidden = false;
+      } else {
+        season.hidden = true;
+      }
+    }
+
+    renderAirQuality(view.airQuality);
+    table.removeAttribute('aria-busy');
+  }
+
+  function renderWarning() {
+    const body = table.querySelector('[data-burn-body]');
+    if (body) {
+      while (body.firstChild) body.removeChild(body.firstChild);
+
+      const cell = document.createElement('td');
+      cell.colSpan = 2;
+      cell.className = 'widget__warning';
+      cell.appendChild(
+        document.createTextNode('⚠ Live fire status unavailable. Call ')
+      );
+
+      const phone = document.createElement('a');
+      phone.setAttribute('href', 'tel:(360) 378-5334');
+      phone.textContent = '(360) 378-5334';
+      cell.appendChild(phone);
+
+      cell.appendChild(document.createTextNode(' or see '));
+
+      const permits = document.createElement('a');
+      permits.setAttribute('href', '/services/burn-permits/');
+      permits.textContent = 'Burn Permits ›';
+      cell.appendChild(permits);
+
+      const row = document.createElement('tr');
+      row.appendChild(cell);
+      body.appendChild(row);
+    }
+
+    // A season range is a status claim; don't show one next to "unavailable".
+    const season = table.querySelector('[data-burn-season]');
+    if (season) season.hidden = true;
+
+    // Not busy any more -- we're done, we just failed.
+    table.removeAttribute('aria-busy');
+  }
+
+  function load() {
+    const controller = new AbortController();
+    const timer = setTimeout(function () { controller.abort(); }, TIMEOUT_MS);
+
+    return fetch(ENDPOINT, { signal: controller.signal })
+      .then(function (response) {
+        if (!response.ok) throw new Error('HTTP ' + response.status);
+        return response.json();
+      })
+      .then(function (payload) {
+        const view = buildView(payload);
+        if (!view) throw new Error('unusable payload');
+        render(view);
+      })
+      .catch(function () {
+        renderWarning();
+      })
+      .then(function () {
+        clearTimeout(timer);
+      });
+  }
+
+  // Exposed so tests can await the patch deterministically instead of sleeping.
+  window.__burnStatusReady = load();
+})();
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `node --test tests/burn-status.test.js`
+Expected: PASS, 4/4.
+
+- [ ] **Step 6: Run the whole unit suite**
+
+Run: `npm run test:unit`
+Expected: PASS. Nothing else should regress.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/js/burn-status.js tests/burn-status.test.js tests/fixtures/agency-status.json
+git commit -m "feat: fetch live burn status and patch the Fire Safety widget
+
+Adds src/js/burn-status.js: fetches the StationWorks agency status endpoint
+on page load, maps the whole payload to a view model before touching the DOM,
+then patches every row in one pass.
+
+Season dates are formatted in UTC -- naive parsing of the date-only strings
+renders 2026-10-06 as Oct 5 in Pacific time."
+```
+
+---
+
+### Task 3: Value normalisation across the confirmed enums
+
+**Files:**
+- Modify: `tests/burn-status.test.js` (append a describe block)
+- Modify: `src/js/burn-status.js` only if a case fails
+
+**Interfaces:**
+- Consumes: `boot`, `ok`, `cell`, `fixture` from Task 2's test file.
+- Produces: nothing new. This task pins behavior Task 2 already implements.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/burn-status.test.js`:
+
+```js
+/** Deep-clones the fixture and applies `mutate` before returning it. */
+function withPayload(mutate) {
+  const payload = JSON.parse(JSON.stringify(fixture));
+  mutate(payload);
+  return payload;
+}
+
+describe("Value normalisation", () => {
+  const FIRE_DANGER = [
+    ["low", "Low", "level--low"],
+    ["moderate", "Moderate", "level--moderate"],
+    ["high", "High", "level--high"],
+    ["very_high", "Very High", "level--very-high"],
+    ["extreme", "Extreme", "level--extreme"],
+  ];
+
+  for (const [token, text, className] of FIRE_DANGER) {
+    it(`renders fireDanger "${token}" as "${text}"`, async () => {
+      const doc = await boot(ok(withPayload((p) => { p.fireDanger = token; })));
+      assert.strictEqual(cell(doc, "fire-danger").textContent.trim(), text);
+      assert.ok(cell(doc, "fire-danger").className.includes(className));
+    });
+  }
+
+  const STATES = [
+    ["open", "Open", "level--open"],
+    ["closed", "Closed", "level--closed"],
+    ["restricted", "Restricted", "level--restricted"],
+  ];
+
+  for (const [token, text, className] of STATES) {
+    it(`renders state "${token}" as "${text}" on a permit row`, async () => {
+      // restricted on a *permit* row is the case the old Tina schema could not
+      // express -- permits were Open/Closed only.
+      const doc = await boot(ok(withPayload((p) => {
+        p.statuses.find((s) => s.slug === "residential").state = token;
+      })));
+      assert.strictEqual(cell(doc, "residential").textContent.trim(), text);
+      assert.ok(cell(doc, "residential").className.includes(className));
+    });
+  }
+
+  for (const separator of ["very high", "very-high"]) {
+    it(`accepts "${separator}" as equivalent to very_high`, async () => {
+      const doc = await boot(ok(withPayload((p) => { p.fireDanger = separator; })));
+      assert.strictEqual(cell(doc, "fire-danger").textContent.trim(), "Very High");
+      assert.ok(cell(doc, "fire-danger").className.includes("level--very-high"));
+    });
+  }
+
+  it("does not title-case airQuality.category", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      p.airQuality.category = "Unhealthy for Sensitive Groups";
+      p.airQuality.pm25Aqi = 130;
+    })));
+    // EPA's own capitalisation -- "for" stays lowercase.
+    assert.strictEqual(
+      doc.querySelector("[data-aqi-label]").textContent,
+      "AQI · Unhealthy for Sensitive Groups"
+    );
+    assert.ok(
+      cell(doc, "air-quality").className
+        .includes("level--aqi-unhealthy-for-sensitive-groups")
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `node --test tests/burn-status.test.js`
+Expected: PASS, all cases. Task 2's implementation already satisfies them — this task exists to prove it and to lock the enums against regression.
+
+If any case fails, fix `slugify`, `titleCase`, `KNOWN_LEVELS`, or `airQualityFor` in `src/js/burn-status.js` — **do not** relax the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/burn-status.test.js
+git commit -m "test: pin fireDanger and state enums to display text and CSS class
+
+Table-driven across all eight confirmed tokens. Covers very_high -> Very High
+/ level--very-high, separator tolerance, and restricted on a permit row --
+a state the old TinaCMS schema could not represent.
+
+Also pins that airQuality.category is not title-cased: EPA's label is
+'Unhealthy for Sensitive Groups', not 'Unhealthy For Sensitive Groups'."
+```
+
+---
+
+### Task 4: Failure and partial-data handling
+
+**Files:**
+- Modify: `tests/burn-status.test.js` (append a describe block)
+- Modify: `src/js/burn-status.js` only if a case fails
+
+**Interfaces:**
+- Consumes: `boot`, `ok`, `cell`, `fixture`, `withPayload` from Tasks 2–3.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/burn-status.test.js`:
+
+```js
+const warning = (doc) => doc.querySelector(".widget__warning");
+
+describe("Failure handling", () => {
+  const FAILURES = [
+    ["a network rejection", () => Promise.reject(new Error("offline"))],
+    ["HTTP 500", () => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) })],
+    ["malformed JSON", () => Promise.resolve({ ok: true, status: 200, json: () => Promise.reject(new SyntaxError("bad")) })],
+    ["a payload with no statuses array", ok({ season: { start: "2026-10-06", end: "2027-06-05" } })],
+    ["a payload with an empty statuses array", ok({ statuses: [] })],
+  ];
+
+  for (const [label, responder] of FAILURES) {
+    it(`shows the warning on ${label}`, async () => {
+      const doc = await boot(responder);
+      const cellEl = warning(doc);
+      assert.ok(cellEl, "expected a warning cell");
+      assert.match(cellEl.textContent, /Live fire status unavailable/);
+      assert.strictEqual(
+        cellEl.querySelector('a[href="tel:(360) 378-5334"]').textContent,
+        "(360) 378-5334"
+      );
+      assert.ok(cellEl.querySelector('a[href="/services/burn-permits/"]'));
+    });
+
+    it(`leaves no half-patched rows on ${label}`, async () => {
+      const doc = await boot(responder);
+      // The whole tbody is replaced, so no status cells survive at all.
+      assert.strictEqual(doc.querySelectorAll("[data-row]").length, 0);
+      assert.strictEqual(doc.querySelector("[data-burn-season]").hidden, true);
+      assert.strictEqual(
+        doc.querySelector("[data-burn-status]").hasAttribute("aria-busy"),
+        false
+      );
+    });
+  }
+});
+
+describe("Partial data", () => {
+  it("shows an em dash for a slug missing from statuses[] and still patches the rest", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      p.statuses = p.statuses.filter((s) => s.slug !== "commercial");
+    })));
+    assert.strictEqual(cell(doc, "commercial").textContent.trim(), "—");
+    assert.ok(cell(doc, "commercial").className.includes("level--unknown"));
+    // Neighbouring rows are unaffected.
+    assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
+    assert.ok(!warning(doc), "a missing slug must not trigger the warning");
+  });
+
+  it("shows an em dash when fireDanger is absent", async () => {
+    const doc = await boot(ok(withPayload((p) => { delete p.fireDanger; })));
+    assert.strictEqual(cell(doc, "fire-danger").textContent.trim(), "—");
+    assert.ok(cell(doc, "fire-danger").className.includes("level--unknown"));
+  });
+
+  it("renders an unrecognised state uncoloured rather than mis-coloured", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      p.statuses.find((s) => s.slug === "residential").state = "partial";
+    })));
+    const target = cell(doc, "residential");
+    assert.strictEqual(target.textContent.trim(), "Partial");
+    assert.strictEqual(target.className, "level");
+  });
+
+  const NO_AQI = [
+    ["airQuality is null", (p) => { p.airQuality = null; }],
+    ["airQuality is absent", (p) => { delete p.airQuality; }],
+    ["pm25Aqi is negative", (p) => { p.airQuality.pm25Aqi = -1; }],
+    ["pm25Aqi is not a number", (p) => { p.airQuality.pm25Aqi = "17"; }],
+  ];
+
+  for (const [label, mutate] of NO_AQI) {
+    it(`hides the air quality row when ${label}`, async () => {
+      const doc = await boot(ok(withPayload(mutate)));
+      assert.strictEqual(doc.querySelector("[data-aqi-row]").hidden, true);
+      assert.ok(!warning(doc), "a missing AQI must not trigger the warning");
+    });
+  }
+
+  it("hides the season line when season is absent", async () => {
+    const doc = await boot(ok(withPayload((p) => { delete p.season; })));
+    assert.strictEqual(doc.querySelector("[data-burn-season]").hidden, true);
+    // Everything else still patches.
+    assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `node --test tests/burn-status.test.js`
+Expected: PASS. Task 2's implementation already covers these paths; fix the implementation, not the test, if any fail.
+
+- [ ] **Step 3: Run the whole unit suite and lint**
+
+Run: `npm run test:unit && npm run lint`
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/burn-status.test.js
+git commit -m "test: cover failure paths and partial payloads
+
+Network rejection, HTTP 500, malformed JSON, and missing/empty statuses all
+produce the warning with a working phone link, clear aria-busy, hide the
+season line, and leave no half-patched rows.
+
+Partial data degrades per-row instead: a missing slug or fireDanger shows an
+em dash, an unrecognised state renders uncoloured rather than mis-coloured,
+and a missing airQuality hides just that row."
+```
+
+---
+
+### Task 5: Retire the hourly workflow and document the new flow
+
+**Files:**
+- Modify: `.github/workflows/update-air-quality.yml:3-9`
+- Modify: `CLAUDE.md` (the "Air Quality (AirNow)" section)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Remove the schedule trigger**
+
+In `.github/workflows/update-air-quality.yml`, replace lines 3–9:
+
+```yaml
+on:
+  schedule:
+    # Hourly (AirNow updates hourly). The fetch script only rewrites the data
+    # file — and thus redeploys the site — when the AQI moves >=5% or its
+    # category changes, so routine hourly runs are no-ops.
+    - cron: '0 * * * *'
+  workflow_dispatch:
+```
+
+with:
+
+```yaml
+on:
+  # No schedule. The Fire Safety widget reads air quality live from the
+  # StationWorks permits API at runtime, so nothing here needs to run on a
+  # timer. Kept manually runnable: this still refreshes src/_data/air_quality.json,
+  # which no longer feeds the site but is retained for now.
+  workflow_dispatch:
+```
+
+Change nothing else in the file. `scripts/generate-air-quality.mjs` stays untouched.
+
+- [ ] **Step 2: Verify the workflow still parses**
+
+Run:
+
+```bash
+node -e "const y=require('fs').readFileSync('.github/workflows/update-air-quality.yml','utf8'); if(/^\s*schedule:/m.test(y)) throw new Error('schedule still present'); if(!/workflow_dispatch:/.test(y)) throw new Error('workflow_dispatch missing'); console.log('ok')"
+```
+
+Expected: prints `ok`.
+
+- [ ] **Step 3: Update CLAUDE.md**
+
+Replace the whole `### Air Quality (AirNow)` section with:
+
+```markdown
+### Fire Safety Widget (Burn Status + Air Quality)
+
+The Fire Safety widget reads **live at runtime** from the StationWorks permits
+API. Nothing about it is baked in at build time.
+
+**Endpoint:** `https://api.permits.stationworks.app/v1/agencies/sjifire/status`
+(CORS-open, no API key, `cache-control: max-age=120`)
+
+One response supplies the whole widget: burn season, fire danger, all five
+permit/recreational statuses, and air quality.
+
+**Files:**
+- `src/_includes/burn-status-widget.liquid` - renders structure only (row labels,
+  placeholder cells, `data-*` hooks). Contains no data references.
+- `src/js/burn-status.js` - fetches on every page load and patches the cells.
+  Maps the entire payload before touching the DOM, so the widget is never
+  half-patched.
+
+**There is no static fallback, deliberately.** If the API is unreachable the
+widget shows "Live fire status unavailable" with the office phone number. A
+stale committed baseline would instead show a confident wrong answer about
+burn permits, which is worse than admitting we don't know.
+
+**Enums** (confirmed with StationWorks):
+- `fireDanger`: `low`, `moderate`, `high`, `very_high`, `extreme`
+- `state`: `open`, `closed`, `restricted` - valid on **every** status row,
+  including residential and commercial permits
+
+Tokens are snake_case; the widget title-cases them for display (`very_high` ->
+"Very High") and slugifies them for the CSS class (`level--very-high`). One
+exception: `airQuality.category` arrives display-ready and is **never**
+title-cased, or EPA's "Unhealthy for Sensitive Groups" would render as
+"Unhealthy For Sensitive Groups".
+
+#### Deprecated: TinaCMS "Burn Status" and the AirNow pipeline
+
+`src/_data/burn_status.json` and `src/_data/air_quality.json` are **no longer read
+by the site.** They remain on disk, and the TinaCMS collection is still present
+but labelled `Burn Status (DEPRECATED — DO NOT EDIT)`.
+
+**Editing burn status in TinaCMS has no effect on the public site and produces no
+error.** Burn status is changed in the StationWorks permits system. Deleting the
+collection and both JSON files is a pending follow-up.
+
+`.github/workflows/update-air-quality.yml` and `scripts/generate-air-quality.mjs`
+are retained and manually runnable (`workflow_dispatch`), but **no longer run on a
+schedule**. The hourly cron produced 214 commits in 16 days -- roughly 13 site
+redeploys a day -- to maintain a number the browser now fetches directly.
+
+**Secrets** (only needed for a manual run):
+- From GitHub Secrets: `AIRNOW_API_KEY`, `DEPLOY_KEY`
+
+**Local Testing:**
+```bash
+export AIRNOW_API_KEY="your-api-key"
+npm run air-quality
+```
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/update-air-quality.yml CLAUDE.md
+git commit -m "chore: stop the hourly AirNow schedule; document the runtime widget
+
+The Fire Safety widget now reads live from the StationWorks permits API, so the
+hourly cron no longer has a consumer. It produced 214 commits in 16 days -- about
+13 redeploys a day. Workflow and script are kept manually runnable via
+workflow_dispatch.
+
+CLAUDE.md documents the new data flow, the confirmed enums, why there is no
+static fallback, and that the TinaCMS Burn Status editor is now inert."
+```
+
+---
+
+### Task 6: End-to-end verification in a real browser
+
+**Files:**
+- Create: `tests/burn-status.spec.js`
+
+**Interfaces:**
+- Consumes: the built site and `src/js/burn-status.js`.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the e2e spec**
+
+Create `tests/burn-status.spec.js`:
+
+```js
+import { test, expect } from "@playwright/test";
+
+const ENDPOINT = "**/v1/agencies/sjifire/status";
+
+const PAYLOAD = {
+  agency: { slug: "sjifire", displayName: "San Juan Island Fire & Rescue" },
+  season: { start: "2026-10-06", end: "2027-06-05" },
+  fireDanger: "very_high",
+  statuses: [
+    { slug: "residential", label: "Residential Burn Permits", state: "restricted" },
+    { slug: "commercial", label: "Commercial Burn Permits", state: "closed" },
+    { slug: "recreational-county", label: "County lands", state: "open" },
+    { slug: "recreational-dnr", label: "State Park & DNR lands", state: "closed" },
+    { slug: "recreational-nps", label: "National Park lands", state: "closed" },
+  ],
+  airQuality: {
+    station: "Anacortes",
+    pm25Aqi: 17,
+    category: "Good",
+    linkUrl: "https://www.airnow.gov/?reportingArea=Anacortes&stateCode=WA",
+  },
+};
+
+// The widget renders on the homepage and in the sidebar of interior pages.
+const PAGES = [
+  { path: "/", name: "homepage" },
+  { path: "/services/burn-permits/", name: "sidebar page" },
+];
+
+test.describe("Fire Safety widget", () => {
+  for (const target of PAGES) {
+    test(`fills every row on the ${target.name}`, async ({ page }) => {
+      await page.route(ENDPOINT, (route) =>
+        route.fulfill({ json: PAYLOAD })
+      );
+      await page.goto(target.path);
+
+      const widget = page.locator("[data-burn-status]");
+
+      await expect(widget.locator('[data-row="fire-danger"]'))
+        .toHaveText("Very High");
+      await expect(widget.locator('[data-row="fire-danger"]'))
+        .toHaveClass(/level--very-high/);
+      await expect(widget.locator('[data-row="residential"]'))
+        .toHaveText("Restricted");
+      await expect(widget.locator('[data-row="residential"]'))
+        .toHaveClass(/level--restricted/);
+      await expect(widget.locator('[data-row="recreational-county"]'))
+        .toHaveText("Open");
+      await expect(widget.locator("[data-season-range]"))
+        .toHaveText("Oct 6-Jun 5");
+      await expect(widget.locator("[data-aqi-score]")).toHaveText("17");
+      await expect(widget).not.toHaveAttribute("aria-busy", "true");
+
+      // No placeholder survives a successful load.
+      await expect(widget.locator(".level--unknown")).toHaveCount(0);
+    });
+  }
+
+  const FAILURES = [
+    ["a 500", (route) => route.fulfill({ status: 500, body: "nope" })],
+    ["a garbage body", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{{{" })],
+    ["an aborted request", (route) => route.abort()],
+  ];
+
+  for (const [label, handler] of FAILURES) {
+    test(`shows the warning on ${label}`, async ({ page }) => {
+      await page.route(ENDPOINT, handler);
+      await page.goto("/");
+
+      const warning = page.locator(".widget__warning");
+      await expect(warning).toBeVisible();
+      await expect(warning).toContainText("Live fire status unavailable");
+      await expect(warning.locator('a[href="tel:(360) 378-5334"]')).toBeVisible();
+      await expect(page.locator("[data-burn-status]"))
+        .not.toHaveAttribute("aria-busy", "true");
+      // Never blank, never half-filled.
+      await expect(page.locator("[data-row]")).toHaveCount(0);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run the e2e spec**
+
+Run: `npx playwright test --config=tests/playwright.config.js burn-status.spec.js`
+Expected: PASS, 5 tests. The config starts `npm run dev` on port 8080 automatically.
+
+If Playwright browsers are not installed, run `npx playwright install chromium` first.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npm test`
+Expected: unit and e2e both pass. `tests/smoke.spec.js` must stay green — it does not assert widget content, so it is unaffected whether the live API is reachable or not.
+
+- [ ] **Step 4: Lint and build**
+
+Run: `npm run lint && npm run build`
+Expected: both exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/burn-status.spec.js
+git commit -m "test: end-to-end coverage for the Fire Safety widget
+
+Route-mocked Playwright tests on both the homepage and a sidebar page: a good
+response fills every row and leaves no placeholders, and a 500, a garbage body,
+and an aborted request each show the warning with a working phone link.
+
+Uses very_high and restricted in the mock payload so the two values with no
+live sighting are exercised in a real browser."
+```
+
+---
+
+## Manual verification before opening a PR
+
+- [ ] Run `npm run dev` and load `http://localhost:8080/` with devtools open. Confirm exactly one request to `api.permits.stationworks.app`, and that the widget matches the live API's current values.
+- [ ] In devtools, throttle to offline and reload. Confirm the warning appears and the phone link dials.
+- [ ] Load an interior page with the sidebar widget (`/services/burn-permits/`) and confirm the script loads once, not twice.
+- [ ] Confirm no console errors on either page.
+- [ ] Open TinaCMS (`npm run tina:dev`) and confirm the Burn Status collection shows `Burn Status (DEPRECATED — DO NOT EDIT)` with the warning description on the first field. **This is the only check that exercises the already-committed `tina/config.ts` change, which has never been typechecked** — `node_modules` was absent when it was written.
+
+## Self-review notes
+
+**Spec coverage:** every section maps to a task — data source and no-static-baseline rationale → Tasks 1–2; field mapping and normalisation → Tasks 2–3; dates → Task 2; failure/partial table → Task 4; CSS → Task 1; CSP → Task 1; workflow → Task 5; Tina deprecation → already committed in `69319a0`; testing → Tasks 2, 3, 4, 6.
+
+**Deliberate deviation from the spec:** the spec's file list says `tina/config.ts` is modified as part of this work; it was committed early, during the design conversation. Noted under "Already on the branch" so nobody does it twice.
+
+**Known untested surface:** `tina/config.ts` cannot be typechecked without `npm install` in this worktree. The manual verification step above is the gate.

--- a/docs/superpowers/plans/2026-08-09-burn-status-from-api.md
+++ b/docs/superpowers/plans/2026-08-09-burn-status-from-api.md
@@ -730,7 +730,11 @@ renders 2026-10-06 as Oct 5 in Pacific time."
 - Consumes: `boot`, `ok`, `cell`, `fixture` from Task 2's test file.
 - Produces: nothing new. This task pins behavior Task 2 already implements.
 
-- [ ] **Step 1: Write the failing tests**
+**These are characterisation tests, not red-green TDD.** Task 2 built the transforms; this task
+locks the full confirmed enums against regression. Expect them to pass on the first run. If one
+fails, Task 2 has a real bug — fix `src/js/burn-status.js`, never the assertion.
+
+- [ ] **Step 1: Write the tests**
 
 Append to `tests/burn-status.test.js`:
 
@@ -836,7 +840,11 @@ Also pins that airQuality.category is not title-cased: EPA's label is
 - Consumes: `boot`, `ok`, `cell`, `fixture`, `withPayload` from Tasks 2–3.
 - Produces: nothing new.
 
-- [ ] **Step 1: Write the failing tests**
+**Characterisation tests, as in Task 3.** Task 2 implemented these paths; expect them to pass on the
+first run. A failure means a real bug in `src/js/burn-status.js` — fix the implementation, never the
+assertion.
+
+- [ ] **Step 1: Write the tests**
 
 Append to `tests/burn-status.test.js`:
 

--- a/docs/superpowers/specs/2026-07-26-aqi-widget-design.md
+++ b/docs/superpowers/specs/2026-07-26-aqi-widget-design.md
@@ -1,0 +1,304 @@
+# Air Quality Widget — Client-Side Data Source
+
+**Date:** 2026-07-26
+**Status:** SUPERSEDED on 2026-08-09 by `2026-08-09-burn-status-from-api-design.md` — never implemented.
+**Branch:** `worktree-aqi-client-side` (based on `origin/main` @ `adb1c2f`)
+
+> **Why this was retired.** The whole Fire Safety widget now reads live from the StationWorks
+> permits API, which supplies air quality alongside burn status in a single fetch. That removed the
+> hourly AirNow commit churn this spec set out to fix, so the remaining reason to build it was
+> hyperlocality alone.
+>
+> **The accuracy argument below still stands and was not refuted.** The replacement uses the API's
+> Anacortes reading — 18.5 mi away across open water — where this spec had identified a corrected
+> PM2.5 sensor 2.5 mi out, on the island. Reviving it means adding a second fetch that overrides
+> the air-quality row after the primary patch. The verified findings here (the 2024 EPA breakpoint
+> table, the official-first tiering, the median-not-mean reasoning) are the reason to keep this
+> document rather than delete it.
+>
+> Its captured fixture, `tests/fixtures/near-me.json`, was left untracked in the
+> `aqi-client-side` worktree and is not carried into this branch.
+
+## Problem
+
+The Fire Safety widget's "Air Quality & Smoke" row is already built and shipped. Its *data
+acquisition* is the problem, in two ways.
+
+**1. It costs a commit and a redeploy.** `.github/workflows/update-air-quality.yml` runs hourly,
+fetches AirNow, and commits `src/_data/air_quality.json` when the reading moves. The workflow does
+throttle — `generate-air-quality.mjs` only rewrites the file when AQI moves ≥5% or the category
+changes — but `main` still carries long runs of consecutive `chore: update air quality data from
+AirNow` commits. The throttle buys least exactly when it matters most: during a smoke event the
+number moves constantly, so commits and redeploys are most frequent precisely when the site is
+under load and the history should stay readable.
+
+**2. The number describes the wrong place.** The live data file reads:
+
+```json
+{ "aqi": 18, "category": "Good", "pollutant": "O3", "reporting_area": "Anacortes" }
+```
+
+Anacortes is 18.5 mi away across open water, and the reported pollutant is **ozone, not PM2.5** —
+the wrong pollutant for wildfire smoke. This is not a defect in the script; it is the honest output
+of AirNow's regulatory network. Verified: the three nearest AirNow monitors to Friday Harbor are
+Victoria Topaz (17.1 mi, Canada), Saturna (17.5 mi, Canada), and Anacortes (18.5 mi). **There is no
+regulatory monitor on San Juan Island.**
+
+`generate-air-quality.mjs` already documents this in its header, and already links the widget to
+the AirNow Fire and Smoke Map "for live, hyperlocal smoke coverage." This design takes the next
+step: read that map's data directly, rather than linking users to a map that disagrees with the
+number printed beside it.
+
+## Solution
+
+Fetch the Fire and Smoke Map's own backing service from the browser. Keep the existing AirNow
+pipeline as a low-frequency, server-rendered baseline.
+
+### Data source
+
+```
+https://near-me.airfire.org/near-me/?lat=48.5343&lng=-123.017&maxDistanceMiles=20&limit=11
+```
+
+This is the endpoint `fire.airnow.gov` itself calls. Verified live on 2026-07-26:
+
+- Returns `access-control-allow-origin: *` — callable cross-origin from the browser.
+- Requires no API key, so nothing needs hiding and there is no shared rate-limited quota.
+- Cleanly separates official from crowd-sourced data: `aqMonitors[]` carries `instrument: "FEM"`
+  and `deployment_type` (`Permanent` / `Temporary`); `purpleAir[]` and `clarity[]` are the low-cost
+  networks.
+- Returns 11 PurpleAir sensors within 20 mi of Friday Harbor, the nearest **2.5 mi** — on the
+  island — measuring **PM2.5**, the pollutant that tracks smoke.
+- PurpleAir entries arrive **already corrected**: each carries `corrected_pm25`, `nowcast`, and a
+  finished `aqi`, with EPA's US-wide PurpleAir correction and NowCast algorithm applied upstream.
+  We do not implement the correction equation.
+
+Captured response committed at `tests/fixtures/near-me.json`.
+
+Fields used:
+
+- **`aqMonitors[]`** — `{ site_name, source, deployment_type, instrument, nowcast, raw_pm25,
+  distanceMiles, local_ts }`
+- **`purpleAir[]`** — `{ unit_id, aqi, corrected_pm25, nowcast, raw_pm25, status, latency_mins,
+  distanceMiles, direction, local_ts, trend }`
+
+### Known risk: the endpoint is undocumented
+
+There is no published contract, SLA, or terms of use for `near-me.airfire.org`. EPA could change
+the shape or drop the permissive CORS header without notice.
+
+This is acceptable because of the fallback structure below: if the fetch fails, the widget keeps
+showing the server-rendered AirNow value. The failure mode is "the number is less local than it
+could be," not "the widget is broken." Nothing in the build depends on it.
+
+## Architecture
+
+Progressive enhancement. The server renders an AirNow baseline; the browser upgrades it in place.
+
+```
+Server render (Eleventy, from air_quality.json):   AQI 18 · Anacortes (O3)
+                    ↓ client-side JS, on success
+Client render:                                     AQI  2 · Sensor 2.5 mi (PM2.5)
+```
+
+No-JS users, first paint, and any fetch failure all land on the AirNow value. Success upgrades it.
+
+### `.github/workflows/update-air-quality.yml` (modified)
+
+Change the cron from hourly (`0 * * * *`) to **daily**. Nothing else changes — the ≥5% /
+category-change throttle in `generate-air-quality.mjs` stays and still suppresses no-op commits.
+
+This is now a *baseline* generator, not the live number, so daily resolution suffices. Commits drop
+roughly 24×.
+
+Update the cron comment, which currently explains the hourly cadence and would otherwise mislead.
+
+### `scripts/generate-air-quality.mjs` (unchanged)
+
+No changes. It keeps producing the AirNow baseline exactly as today, including its
+leave-the-file-alone-on-API-failure behaviour.
+
+### `src/_includes/burn-status-widget.liquid` (modified)
+
+Keep the existing row and its server-rendered content. Add stable hooks so JS can patch in place
+rather than rebuild markup:
+
+- `id="aqi-row"` on the `<tr>`
+- `id="aqi-cell"` on the `<td class="level ...">`
+- `id="aqi-score"` on `.level__score`
+- `id="aqi-label"` on `.level__label`
+- `id="aqi-source"` on the `<aside>`
+
+The `{% if air_quality.aqi %}` guard, the `<a href="{{ air_quality.source_url }}">` link to the
+Fire and Smoke Map, and all existing classes stay as they are.
+
+Load the script from within the partial, so it ships only where the widget renders:
+
+```liquid
+<script defer src="/js/air-quality.js"></script>
+```
+
+The widget renders at `page.liquid:20` (sidebar) and `homepage.liquid:110` — never both on one
+page, so no duplicate load.
+
+### `src/css/site.css` (unchanged)
+
+No changes. All six EPA categories already exist at `site.css:1320-1349` (`level--aqi-good`,
+`-moderate`, `-unhealthy-for-sensitive-groups`, `-unhealthy`, `-very-unhealthy`, `-hazardous`),
+along with `.level__score`, `.level__label`, and `.widget__nowrap`. The client-side code reuses
+these class names verbatim.
+
+### `src/js/air-quality.js` (new)
+
+Plain browser IIFE matching the `src/js/carousel.js` / `gallery.js` convention — no modules, no
+build step, early-return guard, 2-space indent. Passthrough-copied to `/js/` by `.eleventy.js:35`.
+
+Flow: read `localStorage`; if stale, fetch; on success select a reading and patch the DOM; on any
+failure leave the server-rendered baseline untouched.
+
+**Dual-mode export** so the pure logic is unit-testable under `node --test`:
+
+```js
+(function () {
+  'use strict';
+
+  function selectReading(payload) { /* pure — no DOM, no network */ }
+  function pm25ToAqi(pm) { /* pure */ }
+  function aqiCategory(aqi) { /* pure */ }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { selectReading, pm25ToAqi, aqiCategory };
+    return; // never touch the DOM under Node
+  }
+
+  // browser-only: cache, fetch, patch DOM
+})();
+```
+
+#### Reading selection — official first
+
+`selectReading(payload)` returns `null` if every tier fails, which is the signal to leave the
+baseline alone.
+
+1. **Nearby official monitor.** `aqMonitors[]` entries with `distanceMiles <= 10`, nearest wins.
+   Covers both `Permanent` and `Temporary` deployments.
+2. **On-island corrected sensors.** `purpleAir[]` entries with `status === 0` and
+   `distanceMiles <= 10`. Report the **median** `aqi`.
+3. **Nearest official monitor at any distance.** Closest `aqMonitors[]` entry, unbounded.
+4. **Nothing.** Return `null`.
+
+**Why official-first with a distance gate.** Regulatory monitors are authoritative and citable, so
+they should win — but only when they actually describe local air. Nothing official is within 10 mi
+today, so tier 1 is empty and the widget shows the 2.5 mi sensor. The value of the gate is
+automatic: agencies deploy **temporary official monitors during smoke events**, and those appear in
+`aqMonitors` with `deployment_type: "Temporary"`. The widget then upgrades itself to an official
+reading exactly when officialness matters most, with no code change.
+
+Tiers 1 and 3 are the same source split by distance deliberately: a monitor 18 mi away is a poor
+description of island air (tier 3, last resort) but is still better than nothing.
+
+**Median, not mean, in tier 2.** In the captured fixture three neighbouring sensors read AQI 0–2
+while sensor #78735 read 11. One miscalibrated or smoulder-adjacent sensor must not move the public
+number; the median is robust to that, the mean is not.
+
+Returned shape:
+
+```js
+{ aqi, category, source: 'monitor' | 'sensor', label, distanceMiles, pollutant, sensorCount }
+```
+
+#### PM2.5 → AQI conversion (tiers 1 and 3)
+
+`aqMonitors[]` entries carry **no `aqi` field** — only `nowcast`, which is **PM2.5 in µg/m³**. Both
+official tiers must convert. (Tier 2 needs no conversion; `purpleAir[]` ships a finished `aqi`.)
+
+Use EPA's **2024 revised** PM2.5 breakpoints — the Good band is **0–9.0 µg/m³**, not the legacy
+0–12.0.
+
+This is not a guess. Comparing each sensor's `nowcast` against its service-supplied `aqi` across all
+11 sensors in the fixture, the 2024 table reproduces every value and the legacy table reproduces
+none:
+
+| `nowcast` | service `aqi` | legacy (0–12) | 2024 (0–9) |
+|---|---|---|---|
+| 0.3 | 2 | 1.2 ✗ | 1.7 ✓ |
+| 2.0 | 11 | 8.3 ✗ | 11.1 ✓ |
+| 1.7 | 9 | 7.1 ✗ | 9.4 ✓ |
+| 1.1 | 6 | 4.6 ✗ | 6.1 ✓ |
+
+The legacy table would under-report by roughly 25% and disagree with the Fire and Smoke Map the
+widget links to. Linear interpolation within the band, rounded to nearest integer.
+
+**Clamp negatives to 0.** Monitor `nowcast` can go negative near the detection floor — Anacortes
+reported `-0.4` in the fixture.
+
+#### DOM patch
+
+On a successful reading:
+
+- `#aqi-cell` — swap the `level--aqi-*` class to match the new category, using the same slug
+  convention the Liquid template produces (`category | slugify`).
+- `#aqi-score` — the AQI number.
+- `#aqi-label` — `AQI · <category>`.
+- `#aqi-source` — `Sensor 2.5 mi · PM2.5` for tier 2, or `Nearest monitor: <site_name> · PM2.5` for
+  tiers 1 and 3, matching the existing wording pattern.
+
+The link `href` is left alone; it already points at the Fire and Smoke Map.
+
+Patch all fields or none — never leave the row showing a new score beside a stale category colour.
+
+#### Caching
+
+`localStorage`, TTL **30 minutes**.
+
+The original ask was 5 minutes, sized against AirNow's 500/hr shared-key limit. That limit does not
+apply here — no key, and each visitor spends their own connection rather than a pooled quota.
+Meanwhile the payload reports `latency_mins: 45` and timestamps advance hourly, so a 5-minute TTL
+would re-fetch ~10× per new data point. 30 minutes gives identical freshness for a tenth of the
+requests.
+
+Cache the *selected reading*, not the raw payload.
+
+### `staticwebapp.config.json` (modified)
+
+Add `https://near-me.airfire.org` to `connect-src` in the CSP `globalHeaders`. This is the only
+configuration change and the only security-relevant edit — it widens the CSP by exactly one host.
+
+No routing change: nothing is added under `/api/`, so the `/api/*` admin gate is untouched.
+
+## Testing
+
+**Unit** (`tests/air-quality.test.js`, `node --test`), against `tests/fixtures/near-me.json`:
+
+- tier 1 wins when an official monitor is within 10 mi (synthesised, since the fixture has none)
+- tier 2 is used when no official monitor is within 10 mi — the fixture's real case
+- median selection across multiple in-range sensors
+- outlier sensor does not move the result (the 0/0/2/11 case)
+- `status !== 0` sensors excluded
+- sensors beyond 10 mi excluded
+- tier 3 used when no sensor qualifies and no official monitor is within 10 mi
+- returns `null` when every tier is empty
+- `pm25ToAqi` reproduces the service's own `aqi` for all 11 fixture sensors — the regression test
+  that pins the 2024 breakpoints
+- negative monitor `nowcast` clamps to 0
+- category boundaries at 50/51, 100/101, 150/151, 200/201, 300/301
+
+**E2E** (Playwright), with the network route mocked:
+
+- good response upgrades the row: score, label, source text, and `level--aqi-*` class all change
+- 500 / timeout / malformed body each leave the server-rendered baseline intact and visible
+- fresh `localStorage` entry suppresses a second network call
+- the row is never left empty or half-patched
+
+## Out of scope
+
+- Removing the AirNow pipeline. It stays as the baseline and fallback.
+- Any server-side component. (Rejected alternative: an `/api/aqi` Azure Function proxying AirNow,
+  which would reintroduce the key and the rate limit this design removes.)
+- **`clarity[]` sensors.** The array was empty in the captured payload, so its field shape is
+  unverified; speccing against a structure never observed would be guesswork. Worth revisiting if a
+  Clarity sensor ever appears near the island — it would slot into tier 2.
+- Historical AQI, charts, or trend arrows — the payload carries `trend`, but the widget shows one
+  current number.
+- Adding `src/js/` to the `lint:js` glob. It is currently unlinted; changing that is unrelated
+  cleanup that would touch existing files.

--- a/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
+++ b/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
@@ -150,16 +150,45 @@ build step, early-return guard, 2-space indent. Passthrough-copied to `/js/` by 
 | Recreational Fires: State Park & DNR | `statuses[slug="recreational-dnr"].state` |
 | Recreational Fires: National Parks | `statuses[slug="recreational-nps"].state` |
 
-The API sends lowercase (`"high"`, `"closed"`). Display title-cases each word (`"very high"` →
-`Very High`). The CSS class slugifies: lowercase, then collapse any run of whitespace or
-underscores to a single hyphen (`"very high"` and `"very_high"` both → `level--very-high`). This
-reproduces what Liquid's `slugify` produced before, and is deliberately tolerant because the exact
-casing and separator the API uses for multi-word danger levels has not been observed — only
-`"high"` has been seen live.
+#### Value normalisation
 
-**No new CSS colors are needed.** Every class already exists at `site.css:1296-1349`:
-`level--low`, `--moderate`, `--high`, `--very-high`, `--extreme`, `--open`, `--restricted`,
-`--closed`, and the six `level--aqi-*`.
+`fireDanger` and `state` arrive as **lowercase snake_case machine tokens** — `"high"`, `"closed"`,
+and confirmed by StationWorks, `"very_high"`. Each drives two different outputs, so there are two
+transforms:
+
+```js
+// CSS class suffix: lowercase, runs of whitespace/underscore/hyphen → single hyphen
+slugify("very_high")   // → "very-high"   → class "level--very-high"
+
+// Display text: split on the same separators, capitalise each word, join with spaces
+titleCase("very_high") // → "Very High"
+```
+
+| API token | CSS class | Displayed |
+|---|---|---|
+| `low` | `level--low` | Low |
+| `moderate` | `level--moderate` | Moderate |
+| `high` | `level--high` | High |
+| `very_high` | `level--very-high` | Very High |
+| `extreme` | `level--extreme` | Extreme |
+| `open` | `level--open` | Open |
+| `restricted` | `level--restricted` | Restricted |
+| `closed` | `level--closed` | Closed |
+
+Every class in that table already exists at `site.css:1296-1349`, so **no new CSS colors are
+needed**. Both transforms also accept whitespace- and hyphen-separated input, so `"very high"` and
+`"very-high"` produce identical output to `"very_high"` — the API is snake_case today and the widget
+does not break if that ever changes.
+
+Of the eight tokens, `high`, `open`, `closed` are observed live and `very_high` is confirmed by
+StationWorks. The remaining four (`low`, `moderate`, `extreme`, `restricted`) are inferred from the
+existing TinaCMS enums, which the API appears to mirror. If any turns out to use a different word,
+it renders as readable uncolored text — never a wrong color — per the unrecognised-value rule below.
+
+**`airQuality.category` is the exception: do not title-case it.** It arrives display-ready
+(`"Good"`), and EPA's own label is `"Unhealthy for Sensitive Groups"` — title-casing every word
+would render `Unhealthy For Sensitive Groups`, which is wrong. Use the string verbatim for display
+and only slugify it for the `level--aqi-*` class, exactly as the Liquid template did.
 
 #### Dates
 
@@ -258,7 +287,13 @@ reads them after this change.
 
 - full fixture patches all seven rows, the season header, and the AQI link `href`
 - `aria-busy` is removed on success and retained on failure
-- lowercase API values render title-cased with the correct `level--*` class
+- **table-driven over every token in the normalisation table above** — each of `low`, `moderate`,
+  `high`, `very_high`, `extreme`, `open`, `restricted`, `closed` produces its expected display text
+  and its expected `level--*` class. `very_high` → `Very High` / `level--very-high` is the case
+  StationWorks confirmed and the one most likely to regress.
+- separator tolerance: `"very high"` and `"very-high"` produce the same output as `"very_high"`
+- `airQuality.category` is **not** title-cased — `"Unhealthy for Sensitive Groups"` renders verbatim
+  with class `level--aqi-unhealthy-for-sensitive-groups`, not `Unhealthy For Sensitive Groups`
 - season renders `Oct 6-Jun 5`, **not** `Oct 5-Jun 4` — the UTC regression test
 - a slug missing from `statuses[]` leaves that one row at `—` and patches the rest
 - absent `airQuality` hides the row; negative and non-numeric `pm25Aqi` also hide it

--- a/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
+++ b/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
@@ -224,6 +224,9 @@ show a new value beside a stale category color, or a half-filled table.
 The last row matters: an unknown state degrades to *uncolored but readable*, never to a wrong color.
 A green "Partial" would be worse than a plain one.
 
+On failure the "Burn Season:" line in the header is hidden too — a season range is a status claim,
+and showing it above an "unavailable" message implies the widget knows more than it does.
+
 The warning replaces the tbody with a single cell:
 
 > ⚠ Live fire status unavailable. Call (360) 378-5334 or see Burn Permits ›
@@ -293,7 +296,8 @@ reads them after this change.
 `fetch`. Fixture at `tests/fixtures/agency-status.json`, the captured live response above.
 
 - full fixture patches all seven rows, the season header, and the AQI link `href`
-- `aria-busy` is removed on success and retained on failure
+- `aria-busy` is removed on **both** success and failure — the widget is no longer loading either
+  way, and leaving it set would tell a screen reader the content is still arriving
 - **table-driven over the full confirmed enums** — each of `low`, `moderate`, `high`, `very_high`,
   `extreme`, `open`, `restricted`, `closed` produces its expected display text and its expected
   `level--*` class. `very_high` → `Very High` / `level--very-high` is the one most likely to regress.

--- a/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
+++ b/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
@@ -22,9 +22,14 @@ matters:
 | Recreational — DNR / NPS | `Open` | `closed` |
 | Burn season | 2025-10-06 – 2026-06-15 | 2026-10-06 – 2027-06-05 |
 
-The residential row is the one the public acts on. Right now the website tells islanders that
-burning is permitted during a burn ban. That is the defect this design exists to fix; everything
-else here follows from it.
+**Permit availability and burning legality are not the same thing.** Residential burn *permits* are
+currently closed while county-wide residential burning remains allowed for now. So the stale `Open`
+is not telling anyone to burn during a ban — it misstates whether permits can be obtained, next to a
+fire danger level two steps low and a burn season a full year out of date.
+
+That is still the defect this design exists to fix. The widget presents itself as current fire
+safety information and is not current. It drifts silently, nothing in the build catches it, and
+hand-maintained data that only updates when someone remembers to open TinaCMS will keep drifting.
 
 **2. The air quality pipeline costs a commit and a redeploy per reading.**
 `.github/workflows/update-air-quality.yml` runs hourly, fetches AirNow, and commits
@@ -77,9 +82,11 @@ Response headers confirm it is browser-callable and self-throttling:
 
 Considered and rejected: keeping `burn_status.json` as a server-rendered baseline that JS upgrades.
 It reads as the safe choice and is the opposite. A stale baseline means the no-JS path and every
-fetch failure display a **confident, wrong, legally-relevant answer** — "Residential Burn Permits:
-Open" during a ban. A widget that admits it does not know is strictly safer than one that guesses,
-because a visitor who sees a warning goes and checks, and a visitor who sees "Open" lights a fire.
+fetch failure display a **confident, wrong answer** on rows the public reads as authoritative fire
+safety guidance — and today's drift is the proof of how far that goes unnoticed: four misstated
+status rows, a fire danger two levels low, a season a year out of date, no warning anywhere. A
+widget that admits it does not know is safer than one that guesses, because a visitor who sees a
+warning goes and checks.
 
 The cost is real and accepted: no-JS visitors and crawlers never see live status values, only row
 labels and a pointer to the burn permits page.
@@ -216,17 +223,32 @@ in the repo per the explicit request — but nothing runs on a timer and nothing
 
 `scripts/generate-air-quality.mjs` is **unchanged**.
 
+### `tina/config.ts` (modified — deprecation notice only)
+
+The `configBurnStatus` collection keeps working; it is labelled as dead so nobody edits it by
+mistake. Two changes, both using long-stable Tina schema properties:
+
+- Collection `label` → `"Burn Status (DEPRECATED — DO NOT EDIT)"`, so the warning is visible in the
+  sidebar list before anyone opens the screen.
+- A `description` on the first field (`fire_status`, which renders at the top of the form) stating
+  that edits no longer appear on the website, that burn status is now changed in the StationWorks
+  permits system, that **saving here will succeed and change nothing public**, and that the screen
+  will be removed shortly.
+
+The "saving will succeed and change nothing" sentence is the important one. The failure mode is not
+an error; it is silence, and an editor mid-incident needs to be told that explicitly rather than
+inferring it from a label.
+
+No fields are removed and no data is migrated, so this is fully reversible.
+
+> **Follow-up, not covered here.** "Will be removed shortly" is a promise this change does not keep.
+> Deleting the collection, `burn_status.json`, and `air_quality.json` is a separate small change once
+> the API-driven widget has run in production long enough to trust.
+
 ### Deliberately untouched
 
-`src/_data/burn_status.json`, `src/_data/air_quality.json`, and the `configBurnStatus` collection in
-`tina/config.ts` all stay exactly as they are. Nothing reads them after this change.
-
-> **Known trap, accepted with eyes open.** TinaCMS keeps showing a "Burn Status" editor whose edits
-> no longer affect the public site. An editor can change residential permits to `Open` in Tina, see
-> it save, and have the website continue showing `Closed` from the API — with no error and no
-> explanation. This is documented in `CLAUDE.md` as part of this change. Removing the collection
-> from `tina/config.ts` is the fix if it ever bites; it was considered and consciously deferred to
-> keep this diff small and reversible.
+`src/_data/burn_status.json` and `src/_data/air_quality.json` stay exactly as they are. Nothing
+reads them after this change.
 
 ## Testing
 
@@ -253,7 +275,8 @@ in the repo per the explicit request — but nothing runs on a timer and nothing
 ## Out of scope
 
 - **Removing the AirNow pipeline.** The script and workflow stay, manually runnable.
-- **Removing the Tina collection or the orphaned JSON data files.** See the trap note above.
+- **Removing the Tina collection or the orphaned JSON data files.** This change only marks the
+  collection deprecated; deletion is the follow-up noted above.
 - **Per-status `linkUrl`.** The API carries it on each status but sends `null` for all of them
   today. Only `airQuality.linkUrl` is consumed. Worth revisiting if the API starts populating it.
 - **Rendering rows dynamically from `statuses[]`.** Considered — it would let StationWorks add a

--- a/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
+++ b/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
@@ -1,0 +1,268 @@
+# Fire Safety Widget — Runtime Data from the StationWorks Permits API
+
+**Date:** 2026-08-09
+**Status:** Approved, pending implementation plan
+**Branch:** `feat/burn-status-from-api` (based on `origin/main` @ `02c7d16`)
+**Supersedes:** `2026-07-26-aqi-widget-design.md`
+
+## Problem
+
+The Fire Safety widget renders entirely from files committed to the repo, and both of its data
+sources have gone wrong in different ways.
+
+**1. The burn status is stale and contradicts reality.** `src/_data/burn_status.json` is
+TinaCMS-edited by hand. As of today it disagrees with the live permit system on every field that
+matters:
+
+| Field | `burn_status.json` | StationWorks API |
+|---|---|---|
+| Fire danger | `Low` | `high` |
+| Residential burn permits | `Open` | `closed` |
+| Commercial burn permits | `Open` | `closed` |
+| Recreational — DNR / NPS | `Open` | `closed` |
+| Burn season | 2025-10-06 – 2026-06-15 | 2026-10-06 – 2027-06-05 |
+
+The residential row is the one the public acts on. Right now the website tells islanders that
+burning is permitted during a burn ban. That is the defect this design exists to fix; everything
+else here follows from it.
+
+**2. The air quality pipeline costs a commit and a redeploy per reading.**
+`.github/workflows/update-air-quality.yml` runs hourly, fetches AirNow, and commits
+`src/_data/air_quality.json` whenever the value moves. Since the feature merged on 2026-07-24 it has
+produced **214 commits in 16 days** — about 13 site redeploys per day, and the throttle buys least
+during a smoke event, when the number moves constantly and the site is under load.
+
+A single upstream API now serves both concerns.
+
+## Solution
+
+Fetch `https://api.permits.stationworks.app/v1/agencies/sjifire/status` from the browser on every
+page load and render the whole widget from the response. No build-time data, no committed baseline,
+no static fallback.
+
+### Data source
+
+Verified live on 2026-08-09:
+
+```json
+{
+  "agency":   { "slug": "sjifire", "displayName": "San Juan Island Fire & Rescue" },
+  "season":   { "start": "2026-10-06", "end": "2027-06-05" },
+  "fireDanger": "high",
+  "statuses": [
+    { "slug": "residential",          "label": "Residential Burn Permits", "state": "closed",
+      "permitTypeSlug": "residential", "linkUrl": null, "section": null },
+    { "slug": "commercial",           "label": "Commercial Burn Permits",  "state": "closed", ... },
+    { "slug": "recreational-county",  "label": "County lands",             "state": "open",
+      "section": "recreational-fires" },
+    { "slug": "recreational-dnr",     "label": "State Park & DNR lands",   "state": "closed", ... },
+    { "slug": "recreational-nps",     "label": "National Park lands",      "state": "closed", ... }
+  ],
+  "airQuality": { "station": "Anacortes", "pm25Aqi": 17, "category": "Good",
+                  "categoryNumber": 1, "observedAt": "2026-08-09T17:00:00.000Z",
+                  "linkUrl": "https://www.airnow.gov/?reportingArea=Anacortes&stateCode=WA" },
+  "asOf": "2026-08-09T17:35:39.339Z"
+}
+```
+
+Response headers confirm it is browser-callable and self-throttling:
+
+- `access-control-allow-origin: *` — callable cross-origin, no proxy needed.
+- `cache-control: public, max-age=120, stale-while-revalidate=300` — the CDN and the browser HTTP
+  cache absorb repeat loads. **This is why there is no `localStorage` layer:** a client-side cache
+  would duplicate a job the response headers already do correctly.
+- Served via CloudFront; no API key, so nothing needs hiding and there is no shared quota.
+
+### Why no static baseline
+
+Considered and rejected: keeping `burn_status.json` as a server-rendered baseline that JS upgrades.
+It reads as the safe choice and is the opposite. A stale baseline means the no-JS path and every
+fetch failure display a **confident, wrong, legally-relevant answer** — "Residential Burn Permits:
+Open" during a ban. A widget that admits it does not know is strictly safer than one that guesses,
+because a visitor who sees a warning goes and checks, and a visitor who sees "Open" lights a fire.
+
+The cost is real and accepted: no-JS visitors and crawlers never see live status values, only row
+labels and a pointer to the burn permits page.
+
+## Architecture
+
+```
+Server render (Eleventy):   structure only — labels, placeholders, aria-busy="true"
+          ↓  fetch api.permits.stationworks.app  (every page load; HTTP-cached 120s)
+   success:                 all rows patched together, aria-busy removed
+   failure:                 tbody replaced with a single warning row
+```
+
+### `src/_includes/burn-status-widget.liquid` (modified)
+
+Rows stay **hardcoded** — same labels, same order as today. The template stops referencing
+`burn_status` and `air_quality` entirely and instead renders placeholders with stable hooks:
+
+- `data-burn-status` on the `<table>` — the script's mount point and early-return guard
+- `id="burn-season"` on the header `.timeframe`
+- `data-row="fire-danger"` / `"air-quality"` / `"residential"` / `"commercial"` /
+  `"recreational-county"` / `"recreational-dnr"` / `"recreational-nps"` on each `<td class="level">`
+- Inside the air-quality cell, the existing `.level__score`, `.level__label`, and `<aside>` keep
+  their structure; the script patches their text and the anchor's `href`.
+
+Placeholder cells render `—` with `class="level level--unknown"`, and the table carries
+`aria-busy="true"` until the patch completes.
+
+The air-quality cell is the one exception to that shape: it ships its full anchor / `.level__score`
+/ `.level__label` / `<aside>` structure with empty text and an `href` of `#`, and the row starts
+`hidden`. The script unhides it only after a valid `airQuality` block is mapped, so a payload
+without one never flashes an empty row.
+
+The `{% if page.url == '/' %}` footer link stays as-is.
+
+Load the script from within the partial so it ships only where the widget renders:
+
+```liquid
+<script defer src="/js/burn-status.js"></script>
+```
+
+The widget renders at `page.liquid:20` (sidebar) and `homepage.liquid:110` — never both on one page,
+so there is no duplicate load. Both `render` calls drop their now-unused `burn_status:` and
+`air_quality:` arguments.
+
+### `src/js/burn-status.js` (new)
+
+Plain browser IIFE matching the `src/js/carousel.js` / `gallery.js` convention — no modules, no
+build step, early-return guard, 2-space indent. Passthrough-copied to `/js/` by `.eleventy.js:35`.
+
+#### Field mapping
+
+| Widget row | API path |
+|---|---|
+| Burn Season (header) | `season.start` / `season.end` |
+| Fire Danger | `fireDanger` |
+| Air Quality & Smoke | `airQuality.pm25Aqi`, `.category`, `.station`, `.linkUrl` |
+| Residential Burn Permits | `statuses[slug="residential"].state` |
+| Commercial Burn Permits | `statuses[slug="commercial"].state` |
+| Recreational Fires: San Juan County | `statuses[slug="recreational-county"].state` |
+| Recreational Fires: State Park & DNR | `statuses[slug="recreational-dnr"].state` |
+| Recreational Fires: National Parks | `statuses[slug="recreational-nps"].state` |
+
+The API sends lowercase (`"high"`, `"closed"`). Display title-cases each word (`"very high"` →
+`Very High`). The CSS class slugifies: lowercase, then collapse any run of whitespace or
+underscores to a single hyphen (`"very high"` and `"very_high"` both → `level--very-high`). This
+reproduces what Liquid's `slugify` produced before, and is deliberately tolerant because the exact
+casing and separator the API uses for multi-word danger levels has not been observed — only
+`"high"` has been seen live.
+
+**No new CSS colors are needed.** Every class already exists at `site.css:1296-1349`:
+`level--low`, `--moderate`, `--high`, `--very-high`, `--extreme`, `--open`, `--restricted`,
+`--closed`, and the six `level--aqi-*`.
+
+#### Dates
+
+`season.start` and `season.end` are **date-only strings** (`"2026-10-06"`). Parse as UTC and format
+in UTC. Naive `new Date("2026-10-06")` renders as Oct 5 in Pacific time — an off-by-one on a
+public-facing date. Target format is `Oct 6`, matching `postDateTerseNoYearISO`
+(`{ month: "short", day: "numeric" }`, `src/_lib/date-utils.js:176`), producing the existing
+`Burn Season: Oct 6-Jun 5`.
+
+#### Failure and partial data
+
+**Map the entire payload before touching the DOM.** Patch all fields or none — the widget must never
+show a new value beside a stale category color, or a half-filled table.
+
+| Condition | Behavior |
+|---|---|
+| Fetch throws / non-2xx / unparseable JSON | Warning row |
+| No `statuses` array, or it is empty | Warning row |
+| A mapped slug is absent from `statuses[]` | That row alone shows `—` / `level--unknown` |
+| `fireDanger` absent | That row alone shows `—` / `level--unknown` |
+| `airQuality` null or absent | Hide the air-quality row (matches today's `{% if %}`) |
+| `pm25Aqi` non-numeric or negative | Hide the air-quality row |
+| `season` absent | Omit the "Burn Season:" line from the header |
+| Unrecognised state value (e.g. a future `"partial"`) | Render the text, no color class |
+
+The last row matters: an unknown state degrades to *uncolored but readable*, never to a wrong color.
+A green "Partial" would be worse than a plain one.
+
+The warning replaces the tbody with a single cell:
+
+> ⚠ Live fire status unavailable. Call (360) 378-5334 or see Burn Permits ›
+
+`(360) 378-5334` is the office number from `footer.liquid:47`; Burn Permits links to
+`/services/burn-permits/`.
+
+#### Request handling
+
+- `fetch` with an `AbortController` timeout so a hung connection surfaces the warning rather than
+  leaving the skeleton up indefinitely.
+- Default cache mode — the point is to let `max-age=120` work.
+- No retry. The next page load is the retry.
+
+### `src/css/site.css` (modified)
+
+Two small additions only:
+
+- `.level--unknown` — muted placeholder treatment for `—`.
+- A warning-row style for the failure state, using existing widget typography.
+
+### `staticwebapp.config.json` (modified)
+
+Add `https://api.permits.stationworks.app` to `connect-src` in the CSP `globalHeaders`. This widens
+the CSP by exactly one host and is the only security-relevant edit. No routing change — nothing is
+added under `/api/`, so the admin auth gate is untouched.
+
+### `.github/workflows/update-air-quality.yml` (modified)
+
+Remove the `schedule:` block; keep `workflow_dispatch`. The workflow and
+`scripts/generate-air-quality.mjs` remain fully functional and manually runnable — the logic stays
+in the repo per the explicit request — but nothing runs on a timer and nothing auto-commits.
+
+`scripts/generate-air-quality.mjs` is **unchanged**.
+
+### Deliberately untouched
+
+`src/_data/burn_status.json`, `src/_data/air_quality.json`, and the `configBurnStatus` collection in
+`tina/config.ts` all stay exactly as they are. Nothing reads them after this change.
+
+> **Known trap, accepted with eyes open.** TinaCMS keeps showing a "Burn Status" editor whose edits
+> no longer affect the public site. An editor can change residential permits to `Open` in Tina, see
+> it save, and have the website continue showing `Closed` from the API — with no error and no
+> explanation. This is documented in `CLAUDE.md` as part of this change. Removing the collection
+> from `tina/config.ts` is the fix if it ever bites; it was considered and consciously deferred to
+> keep this diff small and reversible.
+
+## Testing
+
+**Unit** (`tests/burn-status.test.js`, `node --test` + JSDOM), matching the existing
+`tests/carousel.test.js` pattern — read the script file, execute it against a constructed DOM, stub
+`fetch`. Fixture at `tests/fixtures/agency-status.json`, the captured live response above.
+
+- full fixture patches all seven rows, the season header, and the AQI link `href`
+- `aria-busy` is removed on success and retained on failure
+- lowercase API values render title-cased with the correct `level--*` class
+- season renders `Oct 6-Jun 5`, **not** `Oct 5-Jun 4` — the UTC regression test
+- a slug missing from `statuses[]` leaves that one row at `—` and patches the rest
+- absent `airQuality` hides the row; negative and non-numeric `pm25Aqi` also hide it
+- unrecognised state renders its text with no color class
+- non-2xx, network rejection, malformed JSON, and empty `statuses` each produce the warning
+- no failure path leaves a partially patched table
+
+**E2E** (`tests/burn-status.spec.js`, Playwright with `page.route` mocking):
+
+- good response fills every row on both the homepage and a sidebar page
+- 500, timeout, and garbage body each show the warning with a working phone link
+- the widget is never blank and never half-filled
+
+## Out of scope
+
+- **Removing the AirNow pipeline.** The script and workflow stay, manually runnable.
+- **Removing the Tina collection or the orphaned JSON data files.** See the trap note above.
+- **Per-status `linkUrl`.** The API carries it on each status but sends `null` for all of them
+  today. Only `airQuality.linkUrl` is consumed. Worth revisiting if the API starts populating it.
+- **Rendering rows dynamically from `statuses[]`.** Considered — it would let StationWorks add a
+  permit type with no deploy, and would use the API's own `section` grouping. Rejected for this pass
+  in favor of keeping today's exact labels and order. A new permit type therefore requires a code
+  change; an unknown slug in the response is ignored.
+- **Hyperlocal PM2.5.** `2026-07-26-aqi-widget-design.md` specced reading `near-me.airfire.org` for
+  an on-island PurpleAir sensor 2.5 mi out. The API's Anacortes reading is 18.5 mi away across open
+  water. That spec is superseded and its accuracy argument remains valid; reviving it would mean a
+  second fetch that overrides the air-quality row.
+- **`asOf` / staleness display.** The payload carries a timestamp; the widget shows current values
+  without a "last updated" line, as today.

--- a/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
+++ b/docs/superpowers/specs/2026-08-09-burn-status-from-api-design.md
@@ -152,9 +152,13 @@ build step, early-return guard, 2-space indent. Passthrough-copied to `/js/` by 
 
 #### Value normalisation
 
-`fireDanger` and `state` arrive as **lowercase snake_case machine tokens** — `"high"`, `"closed"`,
-and confirmed by StationWorks, `"very_high"`. Each drives two different outputs, so there are two
-transforms:
+`fireDanger` and `state` arrive as **lowercase snake_case machine tokens**. Both enums are confirmed
+by StationWorks:
+
+- `fireDanger` — `low`, `moderate`, `high`, `very_high`, `extreme`
+- `state` — `open`, `closed`, `restricted` (**all** status rows, permits included)
+
+Each token drives two different outputs, so there are two transforms:
 
 ```js
 // CSS class suffix: lowercase, runs of whitespace/underscore/hyphen → single hyphen
@@ -180,10 +184,13 @@ needed**. Both transforms also accept whitespace- and hyphen-separated input, so
 `"very-high"` produce identical output to `"very_high"` — the API is snake_case today and the widget
 does not break if that ever changes.
 
-Of the eight tokens, `high`, `open`, `closed` are observed live and `very_high` is confirmed by
-StationWorks. The remaining four (`low`, `moderate`, `extreme`, `restricted`) are inferred from the
-existing TinaCMS enums, which the API appears to mirror. If any turns out to use a different word,
-it renders as readable uncolored text — never a wrong color — per the unrecognised-value rule below.
+**`restricted` on a permit row is new.** The TinaCMS schema only ever allowed `Open`/`Closed` for
+residential and commercial permits — `Restricted` existed solely on the three recreational fields.
+The API allows `restricted` on every status row, so the widget can now express a state the old
+hand-edited data structurally could not. No special handling is required: rows are mapped uniformly
+by slug and `level--restricted` already exists, so this works by construction rather than by a
+per-row rule. It is called out because a reader comparing the two schemas will notice the
+difference, and because the recreational-only assumption must not be carried into the code.
 
 **`airQuality.category` is the exception: do not title-case it.** It arrives display-ready
 (`"Good"`), and EPA's own label is `"Unhealthy for Sensitive Groups"` — title-casing every word
@@ -287,10 +294,11 @@ reads them after this change.
 
 - full fixture patches all seven rows, the season header, and the AQI link `href`
 - `aria-busy` is removed on success and retained on failure
-- **table-driven over every token in the normalisation table above** — each of `low`, `moderate`,
-  `high`, `very_high`, `extreme`, `open`, `restricted`, `closed` produces its expected display text
-  and its expected `level--*` class. `very_high` → `Very High` / `level--very-high` is the case
-  StationWorks confirmed and the one most likely to regress.
+- **table-driven over the full confirmed enums** — each of `low`, `moderate`, `high`, `very_high`,
+  `extreme`, `open`, `restricted`, `closed` produces its expected display text and its expected
+  `level--*` class. `very_high` → `Very High` / `level--very-high` is the one most likely to regress.
+- `restricted` renders correctly on a **permit** row, not just a recreational one — the case the old
+  Tina schema could not represent
 - separator tolerance: `"very high"` and `"very-high"` produce the same output as `"very_high"`
 - `airQuality.category` is **not** title-cased — `"Unhealthy for Sensitive Groups"` renders verbatim
   with class `level--aqi-unhealthy-for-sensitive-groups`, not `Unhealthy For Sensitive Groups`

--- a/src/_includes/burn-status-widget.liquid
+++ b/src/_includes/burn-status-widget.liquid
@@ -1,4 +1,4 @@
-<table class="widget widget--burn-status" data-burn-status aria-busy="true">
+<table class="widget widget--burn-status" data-burn-status>
   <caption class="widget__header">
     <div class="flex">
       <svg aria-hidden="true"><use xlink:href='#flame' /></svg>
@@ -68,4 +68,12 @@
     </tfoot>
   {% endif %}
 </table>
+<noscript>
+  <p class="widget__notice widget__notice--burn-status">
+    &#9888; Live fire status unavailable. Call
+    <a href="tel:+13603785334">(360) 378-5334</a>
+    or see
+    <a href="/services/burn-permits/">Burn Permits &rsaquo;</a>
+  </p>
+</noscript>
 <script defer src="/js/burn-status.js"></script>

--- a/src/_includes/burn-status-widget.liquid
+++ b/src/_includes/burn-status-widget.liquid
@@ -1,77 +1,63 @@
-<table class="widget widget--burn-status">
+<table class="widget widget--burn-status" data-burn-status aria-busy="true">
   <caption class="widget__header">
     <div class="flex">
       <svg aria-hidden="true"><use xlink:href='#flame' /></svg>
       <div>
         <span class="widget__title">Fire Safety</span>
-        <div class="timeframe">
-          Burn Season: {{ burn_status.burn_season_start | postDateTerseNoYearISO }}-{{ burn_status.burn_season_end | postDateTerseNoYearISO }}
+        <div class="timeframe" data-burn-season hidden>
+          Burn Season: <span data-season-range></span>
         </div>
       </div>
     </div>
   </caption>
-  <tbody class="widget__body">
+  <tbody class="widget__body" data-burn-body>
     <tr>
       <th>
         Fire Danger
       </th>
-      <td class="level level--{{ burn_status.fire_status | slugify }}">
-        {{ burn_status.fire_status }}
-      </td>
+      <td class="level level--unknown" data-row="fire-danger">&mdash;</td>
     </tr>
-    {% if air_quality.aqi %}
-    <tr>
+    <tr data-aqi-row hidden>
       <th>
         Air Quality &amp; Smoke
-        {% if air_quality.reporting_area %}<aside>Nearest monitor: {{ air_quality.reporting_area }}{% if air_quality.pollutant %} <span class="widget__nowrap">&middot; {{ air_quality.pollutant }}</span>{% endif %}</aside>{% endif %}
+        <aside data-aqi-source></aside>
       </th>
-      <td class="level level--aqi-{{ air_quality.category | slugify }}">
-        <a href="{{ air_quality.source_url }}" target="_blank" rel="noopener">
-          <span class="level__score">{{ air_quality.aqi }}</span>
-          <span class="level__label">AQI &middot; {{ air_quality.category }}</span>
+      <td class="level" data-row="air-quality">
+        <a href="#" target="_blank" rel="noopener" data-aqi-link>
+          <span class="level__score" data-aqi-score></span>
+          <span class="level__label" data-aqi-label></span>
         </a>
       </td>
     </tr>
-    {% endif %}
     <tr>
       <th>
         Residential Burn Permits
       </th>
-      <td class="level level--{{ burn_status.burn_ban_status | slugify }}">
-        {{ burn_status.burn_ban_status }}
-      </td>
+      <td class="level level--unknown" data-row="residential">&mdash;</td>
     </tr>
     <tr>
       <th>
         Commercial Burn Permits
       </th>
-      <td class="level level--{{ burn_status.commercial_burn_ban_status | slugify }}">
-        {{ burn_status.commercial_burn_ban_status }}
-      </td>
+      <td class="level level--unknown" data-row="commercial">&mdash;</td>
     </tr>
     <tr>
       <th>
         Recreational Fires: San Juan County
       </th>
-      <td class="level level--{{ burn_status.rec_campfire_status | slugify }}">
-        {{ burn_status.rec_campfire_status }}
-      </td>
+      <td class="level level--unknown" data-row="recreational-county">&mdash;</td>
     </tr>
     <tr>
       <th>
         Recreational Fires: State Park & DNR
       </th>
-      <td class="level level--{{ burn_status.state_campfire_status | slugify }}">
-        {{ burn_status.state_campfire_status }}
-      </td>
+      <td class="level level--unknown" data-row="recreational-dnr">&mdash;</td>
     </tr>
     <tr>
       <th>
         Recreational Fires: National Parks
       </th>
-      <td class="level level--{{ burn_status.np_campfire_status | slugify }}">
-        {{ burn_status.np_campfire_status }}
-      </td>
+      <td class="level level--unknown" data-row="recreational-nps">&mdash;</td>
     </tr>
   </tbody>
   {% if page.url == '/' %}
@@ -82,3 +68,4 @@
     </tfoot>
   {% endif %}
 </table>
+<script defer src="/js/burn-status.js"></script>

--- a/src/_includes/page.liquid
+++ b/src/_includes/page.liquid
@@ -17,7 +17,7 @@ layout: base
     <aside class="l-grid__sidebar">
       {% if include_burn_widget %}
         <div class="sidebar-block">
-          {% render "burn-status-widget.liquid", burn_status: burn_status, air_quality: air_quality, page: page %}
+          {% render "burn-status-widget.liquid", page: page %}
         </div>
       {% endif %}
       {% if include_incident_widget %}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1348,6 +1348,26 @@ body {
   color: white;
 }
 
+/* Placeholder shown before the live fetch resolves */
+.widget__body .level--unknown {
+  background-color: #f0f0f0;
+  color: #6b6b6b;
+  font-weight: 400;
+}
+
+/* Shown when the live status API is unreachable */
+.widget__body .widget__warning {
+  padding: 15px 5px;
+  font-size: 0.9em;
+  line-height: 1.4;
+  color: #6b6b6b;
+}
+
+.widget__body .widget__warning a {
+  color: inherit;
+  text-decoration: underline;
+}
+
 .widget__body .level a {
   color: inherit;
   text-decoration: none;

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1248,9 +1248,11 @@ body {
   background-color: var(--lt-gray);
 }
 
-/* Burn-status widget stripes by position so conditionally-hidden rows
-   (e.g. Air Quality when there's no reading) never break the zebra. */
-.widget--burn-status .widget__body tr:nth-of-type(odd) {
+/* Burn-status widget stripes by position among *visible* rows -- the Air
+   Quality row stays in the DOM with [hidden] rather than being removed, and
+   plain :nth-of-type counts it regardless of visibility, which would leave
+   two adjacent visible rows sharing a background when it's hidden. */
+.widget--burn-status .widget__body tr:nth-child(odd of :not([hidden])) {
   background-color: var(--lt-gray);
 }
 
@@ -1361,6 +1363,8 @@ body {
   font-size: 0.9em;
   line-height: 1.4;
   color: #6b6b6b;
+  text-align: left;
+  text-transform: none;
 }
 
 .widget__body .widget__warning a {

--- a/src/js/burn-status.js
+++ b/src/js/burn-status.js
@@ -6,6 +6,12 @@
   const table = document.querySelector('[data-burn-status]');
   if (!table) return;
 
+  // First action: the server never renders aria-busy -- if JS doesn't run
+  // (disabled, blocked, fails to parse), the table must not look permanently
+  // busy. Set it ourselves so the busy state only ever exists while we are
+  // genuinely fetching.
+  table.setAttribute('aria-busy', 'true');
+
   const ENDPOINT = 'https://api.permits.stationworks.app/v1/agencies/sjifire/status';
   const TIMEOUT_MS = 8000;
 
@@ -78,6 +84,20 @@
     return start && end ? start + '-' + end : null;
   }
 
+  // Only http(s) links are safe to write into an anchor's href -- the API is
+  // an external, uncontrolled source, and a `javascript:` URL would execute
+  // in this origin on click. A malformed URL (throws) is treated the same as
+  // an absent one: no link, never a guess.
+  function safeHttpUrl(value) {
+    if (typeof value !== 'string' || !value) return null;
+    try {
+      const url = new URL(value, location.href);
+      return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
   function airQualityFor(aq) {
     if (!aq) return null;
     const aqi = aq.pm25Aqi;
@@ -90,7 +110,7 @@
       label: category ? 'AQI · ' + category : 'AQI',
       className: category ? 'level level--aqi-' + slugify(category) : 'level',
       station: typeof aq.station === 'string' ? aq.station : '',
-      href: typeof aq.linkUrl === 'string' && aq.linkUrl ? aq.linkUrl : null
+      href: safeHttpUrl(aq.linkUrl)
     };
   }
 
@@ -105,6 +125,15 @@
     payload.statuses.forEach(function (status) {
       if (status && typeof status.slug === 'string') bySlug[status.slug] = status;
     });
+
+    // If StationWorks renamed every slug we know about, the payload is a
+    // slug-contract break, not partial data -- show the warning rather than
+    // five permanent, silent em dashes. One or two missing slugs still
+    // degrade per-row below; only a total mismatch is fatal.
+    const matchedSlugs = STATUS_SLUGS.filter(function (slug) {
+      return Object.prototype.hasOwnProperty.call(bySlug, slug);
+    });
+    if (matchedSlugs.length === 0) return null;
 
     const rows = { 'fire-danger': cellFor(payload.fireDanger) };
     STATUS_SLUGS.forEach(function (slug) {
@@ -136,7 +165,15 @@
     if (label) label.textContent = aq.label;
 
     const link = table.querySelector('[data-aqi-link]');
-    if (link && aq.href) link.setAttribute('href', aq.href);
+    if (link) {
+      // No valid link -> plain text, not a dud href="#" that duplicates the
+      // current tab (the anchor still has target="_blank").
+      if (aq.href) {
+        link.setAttribute('href', aq.href);
+      } else {
+        link.removeAttribute('href');
+      }
+    }
 
     const source = table.querySelector('[data-aqi-source]');
     if (source) {
@@ -191,7 +228,7 @@
       );
 
       const phone = document.createElement('a');
-      phone.setAttribute('href', 'tel:(360) 378-5334');
+      phone.setAttribute('href', 'tel:+13603785334');
       phone.textContent = '(360) 378-5334';
       cell.appendChild(phone);
 

--- a/src/js/burn-status.js
+++ b/src/js/burn-status.js
@@ -1,0 +1,242 @@
+// Fire Safety widget -- live burn status from the StationWorks permits API.
+// The server renders structure only; everything below fills it in.
+(function () {
+  'use strict';
+
+  const table = document.querySelector('[data-burn-status]');
+  if (!table) return;
+
+  const ENDPOINT = 'https://api.permits.stationworks.app/v1/agencies/sjifire/status';
+  const TIMEOUT_MS = 8000;
+
+  // The data-row attribute for these rows IS the API's status slug.
+  const STATUS_SLUGS = [
+    'residential',
+    'commercial',
+    'recreational-county',
+    'recreational-dnr',
+    'recreational-nps'
+  ];
+
+  // Tokens we have a colour for. Anything else renders uncoloured rather than
+  // mis-coloured -- a wrong colour on a fire danger row is worse than none.
+  const KNOWN_LEVELS = [
+    'low', 'moderate', 'high', 'very-high', 'extreme',
+    'open', 'closed', 'restricted'
+  ];
+
+  const SEASON_FMT = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC'
+  });
+
+  // "very_high" -> "very-high" (CSS class suffix)
+  function slugify(value) {
+    return String(value).trim().toLowerCase().replace(/[\s_-]+/g, '-');
+  }
+
+  // "very_high" -> "Very High" (display text)
+  function titleCase(value) {
+    return String(value)
+      .trim()
+      .toLowerCase()
+      .split(/[\s_-]+/)
+      .filter(Boolean)
+      .map(function (word) {
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      })
+      .join(' ');
+  }
+
+  function formatSeasonDate(value) {
+    if (typeof value !== 'string') return null;
+    const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (!match) return null;
+    // Force UTC -- naive parsing renders 2026-10-06 as Oct 5 in Pacific time.
+    const date = new Date(match[1] + 'T00:00:00Z');
+    return isNaN(date.getTime()) ? null : SEASON_FMT.format(date);
+  }
+
+  function cellFor(token) {
+    if (typeof token !== 'string' || !token.trim()) {
+      return { text: '—', className: 'level level--unknown' };
+    }
+    const slug = slugify(token);
+    return {
+      text: titleCase(token),
+      className: KNOWN_LEVELS.indexOf(slug) === -1
+        ? 'level'
+        : 'level level--' + slug
+    };
+  }
+
+  function seasonFor(season) {
+    if (!season) return null;
+    const start = formatSeasonDate(season.start);
+    const end = formatSeasonDate(season.end);
+    return start && end ? start + '-' + end : null;
+  }
+
+  function airQualityFor(aq) {
+    if (!aq) return null;
+    const aqi = aq.pm25Aqi;
+    if (typeof aqi !== 'number' || !isFinite(aqi) || aqi < 0) return null;
+    // category arrives display-ready ("Unhealthy for Sensitive Groups").
+    // Slugify it for the class, but never title-case it for display.
+    const category = typeof aq.category === 'string' ? aq.category : '';
+    return {
+      score: String(Math.round(aqi)),
+      label: category ? 'AQI · ' + category : 'AQI',
+      className: category ? 'level level--aqi-' + slugify(category) : 'level',
+      station: typeof aq.station === 'string' ? aq.station : '',
+      href: typeof aq.linkUrl === 'string' && aq.linkUrl ? aq.linkUrl : null
+    };
+  }
+
+  // Map the whole payload up front. Returning null means "show the warning" --
+  // we never patch a partial view.
+  function buildView(payload) {
+    if (!payload || !Array.isArray(payload.statuses) || !payload.statuses.length) {
+      return null;
+    }
+
+    const bySlug = Object.create(null);
+    payload.statuses.forEach(function (status) {
+      if (status && typeof status.slug === 'string') bySlug[status.slug] = status;
+    });
+
+    const rows = { 'fire-danger': cellFor(payload.fireDanger) };
+    STATUS_SLUGS.forEach(function (slug) {
+      rows[slug] = cellFor(bySlug[slug] && bySlug[slug].state);
+    });
+
+    return {
+      rows: rows,
+      season: seasonFor(payload.season),
+      airQuality: airQualityFor(payload.airQuality)
+    };
+  }
+
+  function renderAirQuality(aq) {
+    const row = table.querySelector('[data-aqi-row]');
+    if (!row) return;
+    if (!aq) {
+      row.hidden = true;
+      return;
+    }
+
+    const cell = table.querySelector('[data-row="air-quality"]');
+    if (cell) cell.className = aq.className;
+
+    const score = table.querySelector('[data-aqi-score]');
+    if (score) score.textContent = aq.score;
+
+    const label = table.querySelector('[data-aqi-label]');
+    if (label) label.textContent = aq.label;
+
+    const link = table.querySelector('[data-aqi-link]');
+    if (link && aq.href) link.setAttribute('href', aq.href);
+
+    const source = table.querySelector('[data-aqi-source]');
+    if (source) {
+      source.textContent = '';
+      if (aq.station) {
+        source.appendChild(
+          document.createTextNode('Nearest monitor: ' + aq.station + ' ')
+        );
+        const nowrap = document.createElement('span');
+        nowrap.className = 'widget__nowrap';
+        nowrap.textContent = '· PM2.5';
+        source.appendChild(nowrap);
+      }
+    }
+
+    row.hidden = false;
+  }
+
+  function render(view) {
+    Object.keys(view.rows).forEach(function (key) {
+      const cell = table.querySelector('[data-row="' + key + '"]');
+      if (!cell) return;
+      cell.textContent = view.rows[key].text;
+      cell.className = view.rows[key].className;
+    });
+
+    const season = table.querySelector('[data-burn-season]');
+    const range = table.querySelector('[data-season-range]');
+    if (season && range) {
+      if (view.season) {
+        range.textContent = view.season;
+        season.hidden = false;
+      } else {
+        season.hidden = true;
+      }
+    }
+
+    renderAirQuality(view.airQuality);
+    table.removeAttribute('aria-busy');
+  }
+
+  function renderWarning() {
+    const body = table.querySelector('[data-burn-body]');
+    if (body) {
+      while (body.firstChild) body.removeChild(body.firstChild);
+
+      const cell = document.createElement('td');
+      cell.colSpan = 2;
+      cell.className = 'widget__warning';
+      cell.appendChild(
+        document.createTextNode('⚠ Live fire status unavailable. Call ')
+      );
+
+      const phone = document.createElement('a');
+      phone.setAttribute('href', 'tel:(360) 378-5334');
+      phone.textContent = '(360) 378-5334';
+      cell.appendChild(phone);
+
+      cell.appendChild(document.createTextNode(' or see '));
+
+      const permits = document.createElement('a');
+      permits.setAttribute('href', '/services/burn-permits/');
+      permits.textContent = 'Burn Permits ›';
+      cell.appendChild(permits);
+
+      const row = document.createElement('tr');
+      row.appendChild(cell);
+      body.appendChild(row);
+    }
+
+    // A season range is a status claim; don't show one next to "unavailable".
+    const season = table.querySelector('[data-burn-season]');
+    if (season) season.hidden = true;
+
+    // Not busy any more -- we're done, we just failed.
+    table.removeAttribute('aria-busy');
+  }
+
+  function load() {
+    const controller = new AbortController();
+    const timer = setTimeout(function () { controller.abort(); }, TIMEOUT_MS);
+
+    return fetch(ENDPOINT, { signal: controller.signal })
+      .then(function (response) {
+        if (!response.ok) throw new Error('HTTP ' + response.status);
+        return response.json();
+      })
+      .then(function (payload) {
+        const view = buildView(payload);
+        if (!view) throw new Error('unusable payload');
+        render(view);
+      })
+      .catch(function () {
+        renderWarning();
+      })
+      .then(function () {
+        clearTimeout(timer);
+      });
+  }
+
+  // Exposed so tests can await the patch deterministically instead of sleeping.
+  window.__burnStatusReady = load();
+})();

--- a/src/pages/homepage.liquid
+++ b/src/pages/homepage.liquid
@@ -107,7 +107,7 @@ scripts: '<script src="/js/carousel.js" defer></script>'
 
   <aside class="l-grid__sidebar">
     <div class="sidebar-block">
-      {% render "burn-status-widget.liquid", burn_status: burn_status, air_quality: air_quality, page: page %}
+      {% render "burn-status-widget.liquid", page: page %}
     </div>
     <div class="sidebar-block">
       {% render "call-stats-widget.liquid", stats: stats, page: page %}

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -133,7 +133,7 @@
     }
   },
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://res.cloudinary.com https://*.cloudinary.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://res.cloudinary.com https://api.cloudinary.com https://content.cloudinary.com; frame-src 'self' https://*.facebook.com https://*.facebook.net https://*.arcgis.com https://www.google.com https://maps.google.com https://calendar.google.com https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://vimeo.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://res.cloudinary.com https://*.cloudinary.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://res.cloudinary.com https://api.cloudinary.com https://content.cloudinary.com https://api.permits.stationworks.app; frame-src 'self' https://*.facebook.com https://*.facebook.net https://*.arcgis.com https://www.google.com https://maps.google.com https://calendar.google.com https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://vimeo.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",

--- a/tests/burn-status.spec.js
+++ b/tests/burn-status.spec.js
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+const ENDPOINT = "**/v1/agencies/sjifire/status";
+
+const PAYLOAD = {
+  agency: { slug: "sjifire", displayName: "San Juan Island Fire & Rescue" },
+  season: { start: "2026-10-06", end: "2027-06-05" },
+  fireDanger: "very_high",
+  statuses: [
+    { slug: "residential", label: "Residential Burn Permits", state: "restricted" },
+    { slug: "commercial", label: "Commercial Burn Permits", state: "closed" },
+    { slug: "recreational-county", label: "County lands", state: "open" },
+    { slug: "recreational-dnr", label: "State Park & DNR lands", state: "closed" },
+    { slug: "recreational-nps", label: "National Park lands", state: "closed" },
+  ],
+  airQuality: {
+    station: "Anacortes",
+    pm25Aqi: 17,
+    category: "Good",
+    linkUrl: "https://www.airnow.gov/?reportingArea=Anacortes&stateCode=WA",
+  },
+};
+
+// The widget renders on the homepage and in the sidebar of interior pages.
+const PAGES = [
+  { path: "/", name: "homepage" },
+  { path: "/services/burn-permits/", name: "sidebar page" },
+];
+
+test.describe("Fire Safety widget", () => {
+  for (const target of PAGES) {
+    test(`fills every row on the ${target.name}`, async ({ page }) => {
+      await page.route(ENDPOINT, (route) =>
+        route.fulfill({ json: PAYLOAD })
+      );
+      await page.goto(target.path);
+
+      const widget = page.locator("[data-burn-status]");
+
+      await expect(widget.locator('[data-row="fire-danger"]'))
+        .toHaveText("Very High");
+      await expect(widget.locator('[data-row="fire-danger"]'))
+        .toHaveClass(/level--very-high/);
+      await expect(widget.locator('[data-row="residential"]'))
+        .toHaveText("Restricted");
+      await expect(widget.locator('[data-row="residential"]'))
+        .toHaveClass(/level--restricted/);
+      await expect(widget.locator('[data-row="recreational-county"]'))
+        .toHaveText("Open");
+      await expect(widget.locator("[data-season-range]"))
+        .toHaveText("Oct 6-Jun 5");
+      await expect(widget.locator("[data-aqi-score]")).toHaveText("17");
+      await expect(widget).not.toHaveAttribute("aria-busy", "true");
+
+      // No placeholder survives a successful load.
+      await expect(widget.locator(".level--unknown")).toHaveCount(0);
+    });
+  }
+
+  const FAILURES = [
+    ["a 500", (route) => route.fulfill({ status: 500, body: "nope" })],
+    ["a garbage body", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{{{" })],
+    ["an aborted request", (route) => route.abort()],
+  ];
+
+  for (const [label, handler] of FAILURES) {
+    test(`shows the warning on ${label}`, async ({ page }) => {
+      await page.route(ENDPOINT, handler);
+      await page.goto("/");
+
+      const warning = page.locator(".widget__warning");
+      await expect(warning).toBeVisible();
+      await expect(warning).toContainText("Live fire status unavailable");
+      await expect(warning.locator('a[href="tel:(360) 378-5334"]')).toBeVisible();
+      await expect(page.locator("[data-burn-status]"))
+        .not.toHaveAttribute("aria-busy", "true");
+      // Never blank, never half-filled.
+      await expect(page.locator("[data-row]")).toHaveCount(0);
+    });
+  }
+});

--- a/tests/burn-status.spec.js
+++ b/tests/burn-status.spec.js
@@ -72,11 +72,57 @@ test.describe("Fire Safety widget", () => {
       const warning = page.locator(".widget__warning");
       await expect(warning).toBeVisible();
       await expect(warning).toContainText("Live fire status unavailable");
-      await expect(warning.locator('a[href="tel:(360) 378-5334"]')).toBeVisible();
+      await expect(warning.locator('a[href="tel:+13603785334"]')).toBeVisible();
       await expect(page.locator("[data-burn-status]"))
         .not.toHaveAttribute("aria-busy", "true");
       // Never blank, never half-filled.
       await expect(page.locator("[data-row]")).toHaveCount(0);
     });
   }
+
+  test("removes the AQI href instead of leaving a dud href=\"#\" when linkUrl is null", async ({ page }) => {
+    await page.route(ENDPOINT, (route) =>
+      route.fulfill({ json: { ...PAYLOAD, airQuality: { ...PAYLOAD.airQuality, linkUrl: null } } })
+    );
+    await page.goto("/");
+
+    const link = page.locator("[data-aqi-link]");
+    await expect(link).toBeVisible();
+    expect(await link.getAttribute("href")).toBeNull();
+  });
+
+  test("never writes a javascript: URL from the API into the AQI href", async ({ page }) => {
+    await page.route(ENDPOINT, (route) =>
+      route.fulfill({
+        json: {
+          ...PAYLOAD,
+          airQuality: { ...PAYLOAD.airQuality, linkUrl: "javascript:alert(document.cookie)" },
+        },
+      })
+    );
+    await page.goto("/");
+
+    const link = page.locator("[data-aqi-link]");
+    await expect(link).toBeVisible();
+    expect(await link.getAttribute("href")).toBeNull();
+  });
+});
+
+test.describe("Fire Safety widget, JavaScript disabled", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("shows the static no-JS fallback with a working phone and permits link", async ({ page }) => {
+    await page.goto("/");
+
+    const notice = page.locator(".widget__notice--burn-status");
+    await expect(notice).toBeVisible();
+    await expect(notice).toContainText("Live fire status unavailable");
+    await expect(notice.locator('a[href="tel:+13603785334"]')).toBeVisible();
+    await expect(notice.locator('a[href="/services/burn-permits/"]')).toBeVisible();
+
+    // The un-patched table is still there, but nothing claims to be busy --
+    // no JS ran, so nothing ever set aria-busy in the first place.
+    await expect(page.locator("[data-burn-status]"))
+      .not.toHaveAttribute("aria-busy", "true");
+  });
 });

--- a/tests/burn-status.test.js
+++ b/tests/burn-status.test.js
@@ -129,6 +129,29 @@ describe("Burn status widget", () => {
   });
 });
 
+describe("aria-busy lifecycle", () => {
+  it("sets aria-busy itself, synchronously, rather than relying on server markup", () => {
+    // The server no longer renders aria-busy -- prove the script sets it as
+    // its first action, before the (held-open) fetch has a chance to resolve.
+    const noBusyHtml = WIDGET_HTML.replace(' aria-busy="true"', "");
+    const dom = new JSDOM(noBusyHtml, { runScripts: "dangerously" });
+    let resolveFetch;
+    dom.window.fetch = () => new Promise((resolve) => { resolveFetch = resolve; });
+
+    const el = dom.window.document.createElement("script");
+    el.textContent = script;
+    dom.window.document.body.appendChild(el);
+
+    assert.strictEqual(
+      dom.window.document.querySelector("[data-burn-status]").getAttribute("aria-busy"),
+      "true"
+    );
+
+    resolveFetch({ ok: true, status: 200, json: () => Promise.resolve(fixture) });
+    return dom.window.__burnStatusReady;
+  });
+});
+
 /** Deep-clones the fixture and applies `mutate` before returning it. */
 function withPayload(mutate) {
   const payload = JSON.parse(JSON.stringify(fixture));
@@ -205,6 +228,10 @@ describe("Failure handling", () => {
     ["malformed JSON", () => Promise.resolve({ ok: true, status: 200, json: () => Promise.reject(new SyntaxError("bad")) })],
     ["a payload with no statuses array", ok({ season: { start: "2026-10-06", end: "2027-06-05" } })],
     ["a payload with an empty statuses array", ok({ statuses: [] })],
+    ["a payload where none of the five expected slugs match (wholesale slug rename)",
+      ok(withPayload((p) => {
+        p.statuses.forEach((s) => { s.slug = "renamed-" + s.slug; });
+      }))],
   ];
 
   for (const [label, responder] of FAILURES) {
@@ -214,7 +241,7 @@ describe("Failure handling", () => {
       assert.ok(cellEl, "expected a warning cell");
       assert.match(cellEl.textContent, /Live fire status unavailable/);
       assert.strictEqual(
-        cellEl.querySelector('a[href="tel:(360) 378-5334"]').textContent,
+        cellEl.querySelector('a[href="tel:+13603785334"]').textContent,
         "(360) 378-5334"
       );
       assert.ok(cellEl.querySelector('a[href="/services/burn-permits/"]'));
@@ -243,6 +270,24 @@ describe("Partial data", () => {
     // Neighbouring rows are unaffected.
     assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
     assert.ok(!warning(doc), "a missing slug must not trigger the warning");
+  });
+
+  it("still patches per-row (no warning) when only one of the five expected slugs matches", async () => {
+    // The boundary case just short of a total slug rename (M3): as long as
+    // at least one expected slug is present, this is partial data, not an
+    // unusable payload -- each unmatched row degrades to an em dash on its
+    // own, and the rest of the table still renders.
+    const doc = await boot(ok(withPayload((p) => {
+      p.statuses.forEach((s) => {
+        if (s.slug !== "residential") s.slug = "renamed-" + s.slug;
+      });
+    })));
+    assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
+    assert.strictEqual(cell(doc, "commercial").textContent.trim(), "—");
+    assert.strictEqual(cell(doc, "recreational-county").textContent.trim(), "—");
+    assert.strictEqual(cell(doc, "recreational-dnr").textContent.trim(), "—");
+    assert.strictEqual(cell(doc, "recreational-nps").textContent.trim(), "—");
+    assert.ok(!warning(doc), "at least one matching slug must not trigger the warning");
   });
 
   it("shows an em dash when fireDanger is absent", async () => {
@@ -283,5 +328,51 @@ describe("Partial data", () => {
     // Everything else still patches.
     assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
     assert.ok(!warning(doc), "an absent season must not trigger the warning");
+  });
+});
+
+describe("Air quality link safety", () => {
+  it("rejects a javascript: URL rather than writing it into the href", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      p.airQuality.linkUrl = "javascript:alert(document.cookie)";
+    })));
+    const link = doc.querySelector("[data-aqi-link]");
+    assert.strictEqual(link.getAttribute("href"), null);
+    // The row still renders -- only the link is refused.
+    assert.strictEqual(doc.querySelector("[data-aqi-row]").hidden, false);
+  });
+
+  it("treats an unparseable URL (throws in the URL constructor) as no link", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      // A malformed host (embedded space) -- new URL() throws for this
+      // regardless of base, exercising the safeHttpUrl catch branch.
+      p.airQuality.linkUrl = "http://exa mple.com";
+    })));
+    const link = doc.querySelector("[data-aqi-link]");
+    assert.strictEqual(link.getAttribute("href"), null);
+    // The row still renders -- a bad link degrades to plain text, not a warning.
+    assert.strictEqual(doc.querySelector("[data-aqi-row]").hidden, false);
+    assert.ok(!warning(doc), "a malformed AQI link must not trigger the warning");
+  });
+
+  it("accepts an http: URL, not just https:", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      p.airQuality.linkUrl = "http://example.com/aqi";
+    })));
+    assert.strictEqual(
+      doc.querySelector("[data-aqi-link]").getAttribute("href"),
+      "http://example.com/aqi"
+    );
+  });
+
+  it("removes the href (rather than leaving href=\"#\") when linkUrl is null", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      p.airQuality.linkUrl = null;
+    })));
+    const link = doc.querySelector("[data-aqi-link]");
+    assert.strictEqual(link.getAttribute("href"), null);
+    // The row is still shown and filled in -- only the link is absent.
+    assert.strictEqual(doc.querySelector("[data-aqi-row]").hidden, false);
+    assert.strictEqual(doc.querySelector("[data-aqi-score]").textContent, "17");
   });
 });

--- a/tests/burn-status.test.js
+++ b/tests/burn-status.test.js
@@ -249,6 +249,7 @@ describe("Partial data", () => {
     const doc = await boot(ok(withPayload((p) => { delete p.fireDanger; })));
     assert.strictEqual(cell(doc, "fire-danger").textContent.trim(), "—");
     assert.ok(cell(doc, "fire-danger").className.includes("level--unknown"));
+    assert.ok(!warning(doc), "an absent fireDanger must not trigger the warning");
   });
 
   it("renders an unrecognised state uncoloured rather than mis-coloured", async () => {
@@ -258,6 +259,7 @@ describe("Partial data", () => {
     const target = cell(doc, "residential");
     assert.strictEqual(target.textContent.trim(), "Partial");
     assert.strictEqual(target.className, "level");
+    assert.ok(!warning(doc), "an unrecognised state must not trigger the warning");
   });
 
   const NO_AQI = [
@@ -280,5 +282,6 @@ describe("Partial data", () => {
     assert.strictEqual(doc.querySelector("[data-burn-season]").hidden, true);
     // Everything else still patches.
     assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
+    assert.ok(!warning(doc), "an absent season must not trigger the warning");
   });
 });

--- a/tests/burn-status.test.js
+++ b/tests/burn-status.test.js
@@ -1,0 +1,130 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const { JSDOM } = require("jsdom");
+const fs = require("fs");
+const path = require("path");
+
+const script = fs.readFileSync(
+  path.join(__dirname, "../src/js/burn-status.js"),
+  "utf-8"
+);
+
+const fixture = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "fixtures/agency-status.json"), "utf-8")
+);
+
+const WIDGET_HTML = `<!DOCTYPE html><html><body>
+  <table class="widget widget--burn-status" data-burn-status aria-busy="true">
+    <caption class="widget__header">
+      <div class="timeframe" data-burn-season hidden>
+        Burn Season: <span data-season-range></span>
+      </div>
+    </caption>
+    <tbody class="widget__body" data-burn-body>
+      <tr><th>Fire Danger</th>
+        <td class="level level--unknown" data-row="fire-danger">&mdash;</td></tr>
+      <tr data-aqi-row hidden>
+        <th>Air Quality &amp; Smoke <aside data-aqi-source></aside></th>
+        <td class="level" data-row="air-quality">
+          <a href="#" target="_blank" rel="noopener" data-aqi-link>
+            <span class="level__score" data-aqi-score></span>
+            <span class="level__label" data-aqi-label></span>
+          </a></td></tr>
+      <tr><th>Residential Burn Permits</th>
+        <td class="level level--unknown" data-row="residential">&mdash;</td></tr>
+      <tr><th>Commercial Burn Permits</th>
+        <td class="level level--unknown" data-row="commercial">&mdash;</td></tr>
+      <tr><th>Recreational Fires: San Juan County</th>
+        <td class="level level--unknown" data-row="recreational-county">&mdash;</td></tr>
+      <tr><th>Recreational Fires: State Park &amp; DNR</th>
+        <td class="level level--unknown" data-row="recreational-dnr">&mdash;</td></tr>
+      <tr><th>Recreational Fires: National Parks</th>
+        <td class="level level--unknown" data-row="recreational-nps">&mdash;</td></tr>
+    </tbody>
+  </table>
+</body></html>`;
+
+/**
+ * Boots the widget in a fresh JSDOM with a stubbed fetch, then waits for the
+ * script to finish patching. `responder` receives no args and returns whatever
+ * the stubbed fetch should resolve/reject with.
+ */
+async function boot(responder) {
+  const dom = new JSDOM(WIDGET_HTML, { runScripts: "dangerously" });
+  dom.window.fetch = () => responder();
+  const el = dom.window.document.createElement("script");
+  el.textContent = script;
+  dom.window.document.body.appendChild(el);
+  await dom.window.__burnStatusReady;
+  return dom.window.document;
+}
+
+/** A fetch stub that resolves with `body` as JSON and HTTP 200. */
+function ok(body) {
+  return () => Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  });
+}
+
+const cell = (doc, row) => doc.querySelector(`[data-row="${row}"]`);
+
+describe("Burn status widget", () => {
+  it("patches every status row from the API payload", async () => {
+    const doc = await boot(ok(fixture));
+
+    assert.strictEqual(cell(doc, "fire-danger").textContent.trim(), "High");
+    assert.ok(cell(doc, "fire-danger").className.includes("level--high"));
+
+    assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
+    assert.ok(cell(doc, "residential").className.includes("level--closed"));
+
+    assert.strictEqual(cell(doc, "commercial").textContent.trim(), "Closed");
+    assert.strictEqual(cell(doc, "recreational-county").textContent.trim(), "Open");
+    assert.ok(cell(doc, "recreational-county").className.includes("level--open"));
+    assert.strictEqual(cell(doc, "recreational-dnr").textContent.trim(), "Closed");
+    assert.strictEqual(cell(doc, "recreational-nps").textContent.trim(), "Closed");
+  });
+
+  it("renders the burn season in UTC, not local time", async () => {
+    const doc = await boot(ok(fixture));
+    const season = doc.querySelector("[data-burn-season]");
+    assert.strictEqual(season.hidden, false);
+    // 2026-10-06 / 2027-06-05 -- must not slip to Oct 5 / Jun 4 in Pacific time
+    assert.strictEqual(
+      doc.querySelector("[data-season-range]").textContent.trim(),
+      "Oct 6-Jun 5"
+    );
+  });
+
+  it("fills and reveals the air quality row", async () => {
+    const doc = await boot(ok(fixture));
+    const row = doc.querySelector("[data-aqi-row]");
+    assert.strictEqual(row.hidden, false);
+    assert.strictEqual(doc.querySelector("[data-aqi-score]").textContent, "17");
+    assert.strictEqual(
+      doc.querySelector("[data-aqi-label]").textContent,
+      "AQI · Good"
+    );
+    assert.ok(
+      cell(doc, "air-quality").className.includes("level--aqi-good")
+    );
+    assert.strictEqual(
+      doc.querySelector("[data-aqi-link]").getAttribute("href"),
+      "https://www.airnow.gov/?reportingArea=Anacortes&stateCode=WA"
+    );
+    assert.match(
+      doc.querySelector("[data-aqi-source]").textContent,
+      /Nearest monitor: Anacortes/
+    );
+  });
+
+  it("clears aria-busy once patched", async () => {
+    const doc = await boot(ok(fixture));
+    assert.strictEqual(
+      doc.querySelector("[data-burn-status]").hasAttribute("aria-busy"),
+      false
+    );
+  });
+});

--- a/tests/burn-status.test.js
+++ b/tests/burn-status.test.js
@@ -128,3 +128,70 @@ describe("Burn status widget", () => {
     );
   });
 });
+
+/** Deep-clones the fixture and applies `mutate` before returning it. */
+function withPayload(mutate) {
+  const payload = JSON.parse(JSON.stringify(fixture));
+  mutate(payload);
+  return payload;
+}
+
+describe("Value normalisation", () => {
+  const FIRE_DANGER = [
+    ["low", "Low", "level--low"],
+    ["moderate", "Moderate", "level--moderate"],
+    ["high", "High", "level--high"],
+    ["very_high", "Very High", "level--very-high"],
+    ["extreme", "Extreme", "level--extreme"],
+  ];
+
+  for (const [token, text, className] of FIRE_DANGER) {
+    it(`renders fireDanger "${token}" as "${text}"`, async () => {
+      const doc = await boot(ok(withPayload((p) => { p.fireDanger = token; })));
+      assert.strictEqual(cell(doc, "fire-danger").textContent.trim(), text);
+      assert.ok(cell(doc, "fire-danger").className.includes(className));
+    });
+  }
+
+  const STATES = [
+    ["open", "Open", "level--open"],
+    ["closed", "Closed", "level--closed"],
+    ["restricted", "Restricted", "level--restricted"],
+  ];
+
+  for (const [token, text, className] of STATES) {
+    it(`renders state "${token}" as "${text}" on a permit row`, async () => {
+      // restricted on a *permit* row is the case the old Tina schema could not
+      // express -- permits were Open/Closed only.
+      const doc = await boot(ok(withPayload((p) => {
+        p.statuses.find((s) => s.slug === "residential").state = token;
+      })));
+      assert.strictEqual(cell(doc, "residential").textContent.trim(), text);
+      assert.ok(cell(doc, "residential").className.includes(className));
+    });
+  }
+
+  for (const separator of ["very high", "very-high"]) {
+    it(`accepts "${separator}" as equivalent to very_high`, async () => {
+      const doc = await boot(ok(withPayload((p) => { p.fireDanger = separator; })));
+      assert.strictEqual(cell(doc, "fire-danger").textContent.trim(), "Very High");
+      assert.ok(cell(doc, "fire-danger").className.includes("level--very-high"));
+    });
+  }
+
+  it("does not title-case airQuality.category", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      p.airQuality.category = "Unhealthy for Sensitive Groups";
+      p.airQuality.pm25Aqi = 130;
+    })));
+    // EPA's own capitalisation -- "for" stays lowercase.
+    assert.strictEqual(
+      doc.querySelector("[data-aqi-label]").textContent,
+      "AQI · Unhealthy for Sensitive Groups"
+    );
+    assert.ok(
+      cell(doc, "air-quality").className
+        .includes("level--aqi-unhealthy-for-sensitive-groups")
+    );
+  });
+});

--- a/tests/burn-status.test.js
+++ b/tests/burn-status.test.js
@@ -195,3 +195,90 @@ describe("Value normalisation", () => {
     );
   });
 });
+
+const warning = (doc) => doc.querySelector(".widget__warning");
+
+describe("Failure handling", () => {
+  const FAILURES = [
+    ["a network rejection", () => Promise.reject(new Error("offline"))],
+    ["HTTP 500", () => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) })],
+    ["malformed JSON", () => Promise.resolve({ ok: true, status: 200, json: () => Promise.reject(new SyntaxError("bad")) })],
+    ["a payload with no statuses array", ok({ season: { start: "2026-10-06", end: "2027-06-05" } })],
+    ["a payload with an empty statuses array", ok({ statuses: [] })],
+  ];
+
+  for (const [label, responder] of FAILURES) {
+    it(`shows the warning on ${label}`, async () => {
+      const doc = await boot(responder);
+      const cellEl = warning(doc);
+      assert.ok(cellEl, "expected a warning cell");
+      assert.match(cellEl.textContent, /Live fire status unavailable/);
+      assert.strictEqual(
+        cellEl.querySelector('a[href="tel:(360) 378-5334"]').textContent,
+        "(360) 378-5334"
+      );
+      assert.ok(cellEl.querySelector('a[href="/services/burn-permits/"]'));
+    });
+
+    it(`leaves no half-patched rows on ${label}`, async () => {
+      const doc = await boot(responder);
+      // The whole tbody is replaced, so no status cells survive at all.
+      assert.strictEqual(doc.querySelectorAll("[data-row]").length, 0);
+      assert.strictEqual(doc.querySelector("[data-burn-season]").hidden, true);
+      assert.strictEqual(
+        doc.querySelector("[data-burn-status]").hasAttribute("aria-busy"),
+        false
+      );
+    });
+  }
+});
+
+describe("Partial data", () => {
+  it("shows an em dash for a slug missing from statuses[] and still patches the rest", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      p.statuses = p.statuses.filter((s) => s.slug !== "commercial");
+    })));
+    assert.strictEqual(cell(doc, "commercial").textContent.trim(), "—");
+    assert.ok(cell(doc, "commercial").className.includes("level--unknown"));
+    // Neighbouring rows are unaffected.
+    assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
+    assert.ok(!warning(doc), "a missing slug must not trigger the warning");
+  });
+
+  it("shows an em dash when fireDanger is absent", async () => {
+    const doc = await boot(ok(withPayload((p) => { delete p.fireDanger; })));
+    assert.strictEqual(cell(doc, "fire-danger").textContent.trim(), "—");
+    assert.ok(cell(doc, "fire-danger").className.includes("level--unknown"));
+  });
+
+  it("renders an unrecognised state uncoloured rather than mis-coloured", async () => {
+    const doc = await boot(ok(withPayload((p) => {
+      p.statuses.find((s) => s.slug === "residential").state = "partial";
+    })));
+    const target = cell(doc, "residential");
+    assert.strictEqual(target.textContent.trim(), "Partial");
+    assert.strictEqual(target.className, "level");
+  });
+
+  const NO_AQI = [
+    ["airQuality is null", (p) => { p.airQuality = null; }],
+    ["airQuality is absent", (p) => { delete p.airQuality; }],
+    ["pm25Aqi is negative", (p) => { p.airQuality.pm25Aqi = -1; }],
+    ["pm25Aqi is not a number", (p) => { p.airQuality.pm25Aqi = "17"; }],
+  ];
+
+  for (const [label, mutate] of NO_AQI) {
+    it(`hides the air quality row when ${label}`, async () => {
+      const doc = await boot(ok(withPayload(mutate)));
+      assert.strictEqual(doc.querySelector("[data-aqi-row]").hidden, true);
+      assert.ok(!warning(doc), "a missing AQI must not trigger the warning");
+    });
+  }
+
+  it("hides the season line when season is absent", async () => {
+    const doc = await boot(ok(withPayload((p) => { delete p.season; })));
+    assert.strictEqual(doc.querySelector("[data-burn-season]").hidden, true);
+    // Everything else still patches.
+    assert.strictEqual(cell(doc, "residential").textContent.trim(), "Closed");
+  });
+});

--- a/tests/carousel.spec.js
+++ b/tests/carousel.spec.js
@@ -1,7 +1,34 @@
 import { test, expect } from "@playwright/test";
 
+// The homepage's Fire Safety widget fetches this endpoint live on every load.
+// Mock it here so these unrelated specs don't make a real cross-internet
+// request per navigation and don't risk a late DOM mutation from the widget
+// patching in after the page has already settled.
+const BURN_STATUS_ENDPOINT = "**/v1/agencies/sjifire/status";
+const BURN_STATUS_PAYLOAD = {
+  agency: { slug: "sjifire", displayName: "San Juan Island Fire & Rescue" },
+  season: { start: "2026-10-06", end: "2027-06-05" },
+  fireDanger: "moderate",
+  statuses: [
+    { slug: "residential", label: "Residential Burn Permits", state: "open" },
+    { slug: "commercial", label: "Commercial Burn Permits", state: "open" },
+    { slug: "recreational-county", label: "County lands", state: "open" },
+    { slug: "recreational-dnr", label: "State Park & DNR lands", state: "open" },
+    { slug: "recreational-nps", label: "National Park lands", state: "open" },
+  ],
+  airQuality: {
+    station: "Anacortes",
+    pm25Aqi: 12,
+    category: "Good",
+    linkUrl: "https://www.airnow.gov/?reportingArea=Anacortes&stateCode=WA",
+  },
+};
+
 test.describe("Carousel", () => {
   test.beforeEach(async ({ page }) => {
+    await page.route(BURN_STATUS_ENDPOINT, (route) =>
+      route.fulfill({ json: BURN_STATUS_PAYLOAD })
+    );
     await page.goto("/");
   });
 

--- a/tests/fixtures/agency-status.json
+++ b/tests/fixtures/agency-status.json
@@ -1,0 +1,21 @@
+{
+  "agency": { "slug": "sjifire", "displayName": "San Juan Island Fire & Rescue" },
+  "season": { "start": "2026-10-06", "end": "2027-06-05" },
+  "fireDanger": "high",
+  "statuses": [
+    { "slug": "residential", "label": "Residential Burn Permits", "state": "closed", "permitTypeSlug": "residential", "linkUrl": null, "section": null },
+    { "slug": "commercial", "label": "Commercial Burn Permits", "state": "closed", "permitTypeSlug": "commercial", "linkUrl": null, "section": null },
+    { "slug": "recreational-county", "label": "County lands", "state": "open", "permitTypeSlug": null, "linkUrl": null, "section": "recreational-fires" },
+    { "slug": "recreational-dnr", "label": "State Park & DNR lands", "state": "closed", "permitTypeSlug": null, "linkUrl": null, "section": "recreational-fires" },
+    { "slug": "recreational-nps", "label": "National Park lands", "state": "closed", "permitTypeSlug": null, "linkUrl": null, "section": "recreational-fires" }
+  ],
+  "airQuality": {
+    "station": "Anacortes",
+    "pm25Aqi": 17,
+    "category": "Good",
+    "categoryNumber": 1,
+    "observedAt": "2026-08-09T17:00:00.000Z",
+    "linkUrl": "https://www.airnow.gov/?reportingArea=Anacortes&stateCode=WA"
+  },
+  "asOf": "2026-08-09T17:35:39.339Z"
+}

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -1,5 +1,29 @@
 import { test, expect } from "@playwright/test";
 
+// The Fire Safety widget (homepage + several interior pages below) fetches
+// this endpoint live on every load. Mock it here so this suite doesn't make
+// a real cross-internet request per navigation and doesn't risk a late DOM
+// mutation from the widget patching in after the page has already settled.
+const BURN_STATUS_ENDPOINT = "**/v1/agencies/sjifire/status";
+const BURN_STATUS_PAYLOAD = {
+  agency: { slug: "sjifire", displayName: "San Juan Island Fire & Rescue" },
+  season: { start: "2026-10-06", end: "2027-06-05" },
+  fireDanger: "moderate",
+  statuses: [
+    { slug: "residential", label: "Residential Burn Permits", state: "open" },
+    { slug: "commercial", label: "Commercial Burn Permits", state: "open" },
+    { slug: "recreational-county", label: "County lands", state: "open" },
+    { slug: "recreational-dnr", label: "State Park & DNR lands", state: "open" },
+    { slug: "recreational-nps", label: "National Park lands", state: "open" },
+  ],
+  airQuality: {
+    station: "Anacortes",
+    pm25Aqi: 12,
+    category: "Good",
+    linkUrl: "https://www.airnow.gov/?reportingArea=Anacortes&stateCode=WA",
+  },
+};
+
 // Key pages to test
 const pages = [
   { path: "/", name: "Homepage" },
@@ -22,6 +46,12 @@ const pages = [
 ];
 
 test.describe("Smoke Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(BURN_STATUS_ENDPOINT, (route) =>
+      route.fulfill({ json: BURN_STATUS_PAYLOAD })
+    );
+  });
+
   for (const page of pages) {
     test(`${page.name} loads without errors`, async ({ page: browserPage }) => {
       const errors = [];

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
     collections: [
       {
         name: "configBurnStatus",
-        label: "Burn Status",
+        label: "Burn Status (DEPRECATED — DO NOT EDIT)",
         path: "src/_data",
         format: "json",
         match: {
@@ -67,6 +67,12 @@ export default defineConfig({
             type: "string",
             name: "fire_status",
             label: "Fire Danger Level",
+            description:
+              "⚠️ DEPRECATED — EDITS HERE NO LONGER APPEAR ON THE WEBSITE. " +
+              "The Fire Safety widget now reads live from the StationWorks permits " +
+              "system on every page load. Change burn status there, not here. " +
+              "Saving on this screen will succeed and change nothing public. " +
+              "This screen will be removed shortly.",
             options: ["Low", "Moderate", "High", "Very High", "Extreme"],
             required: true,
           },


### PR DESCRIPTION
Replaces the Fire Safety widget's two committed data files with a single live browser fetch of the StationWorks permits API.

## Why

**The burn status was stale and wrong.** `burn_status.json` is hand-edited in TinaCMS and had drifted from the live permit system on every field that matters — fire danger `Low` vs `high`, residential permits `Open` vs `closed`, and a burn season a full year out of date. Nothing in the build catches that drift, and hand-maintained data only updates when someone remembers to open the editor.

To be precise about the risk: permit availability and burning legality are not the same thing. Residential *permits* are closed while county-wide residential burning remains allowed, so the stale `Open` misstated permit availability rather than telling anyone to burn during a ban. Still wrong, still on the row the public reads as authoritative.

**The air quality pipeline cost a commit and a redeploy per reading.** The hourly AirNow cron produced **214 commits in 16 days** — about 13 site redeploys a day — and the throttle bought least during a smoke event, exactly when the number moves constantly and the site is under load.

One upstream API now serves both.

## How

`https://api.permits.stationworks.app/v1/agencies/sjifire/status` — CORS-open, no API key, `cache-control: max-age=120`. One response supplies burn season, fire danger, all five permit/recreational statuses, and air quality.

Eleventy renders structure only — row labels, placeholder cells, `data-*` hooks. `src/js/burn-status.js` fetches on every page load and patches the cells. The response's cache headers are the only throttle; there is deliberately no `localStorage` layer.

## No static fallback, deliberately

If the API is unreachable the widget says so, with the office phone number — it does not fall back to committed data.

A stale baseline would show a **confident wrong answer** on a row the public reads as fire safety guidance, on exactly the no-JS and fetch-failure paths where nobody is watching. A widget that admits it doesn't know is safer than one that guesses: a visitor who sees a warning goes and checks.

The whole payload is mapped before any DOM write, so the table is never half-patched. An unrecognised status value renders as readable **uncoloured** text rather than a wrong colour. A single missing slug degrades that one row to an em dash; only an unusable payload — or zero of five slugs matching — shows the warning.

## Also in this PR

- **Hourly cron removed.** `update-air-quality.yml` keeps `workflow_dispatch`, and `generate-air-quality.mjs` is unchanged — the logic stays in the repo, just off the timer.
- **TinaCMS "Burn Status" marked deprecated.** The collection still exists but is labelled `DO NOT EDIT`, with a field description stating that saving there will succeed and change nothing public. The failure mode is silence, so it says so explicitly.
- **CSP widened by exactly one host** in `connect-src`. No routing or auth change.
- `burn_status.json` and `air_quality.json` remain on disk, unread. Deleting them and the Tina collection is a deliberate follow-up.

## Confirmed with StationWorks

- `fireDanger`: `low`, `moderate`, `high`, `very_high`, `extreme`
- `state`: `open`, `closed`, `restricted` — valid on **every** row, including permits

`restricted` on a permit row is genuinely new; the old Tina schema allowed `Open`/`Closed` only there. Tokens are snake_case, title-cased for display (`very_high` → `Very High`) and slugified for the CSS class (`level--very-high`). All eight classes already existed — no new colours. One exception: `airQuality.category` arrives display-ready and is never title-cased, or EPA's "Unhealthy for Sensitive Groups" would render "Unhealthy For Sensitive Groups".

## Testing

**440 unit tests** (jsdom) and **8 Playwright tests** covering this widget, plus lint and build clean. Coverage includes every enum token, separator tolerance, UTC season dates (`Oct 6`, not `Oct 5` in Pacific), all five unusable-payload shapes, per-row partial degradation, and the no-JS path. The e2e mock deliberately uses `very_high` and `restricted` — the two values never yet observed live — so they are exercised in a real browser.

A review pass found and fixed a **`javascript:` URL injection**: `airQuality.linkUrl` reached an `href` with only a non-empty-string check, and `script-src 'unsafe-inline'` means CSP would not have stopped it. Now scheme-validated to http/https, verified against mixed case, embedded newlines, C0 controls, and polyglot payloads.

## Known: CI will fail on `npm ci`

`package-lock.json` is out of sync with `package.json` on `main` (~16 `@aws-sdk`/`@smithy` mismatches), and both `ci.yml` and the Azure workflow use `npm ci`. **This predates this branch and is unrelated to it** — `claude/update-dependencies-5FQsf` is the fix. Locally verified with `npm install --no-save`.

`admin.spec.js` also fails, both here and on `main` — `/admin/` needs `npm run tina:build`, which the Playwright dev server never runs.

## Before merging

Open `npm run tina:dev` and confirm the deprecated Burn Status label renders. It is the one change in this branch never seen in a running editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)