### PR TITLE
Stop PR previews from rewriting the production schema index

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-moss-0db15021e.yml
@@ -88,6 +88,26 @@ jobs:
       - name: Build TinaCMS and index schema
         run: npx tinacms build --skip-cloud-checks
         env:
+          # Only index into the shared production Cosmos collection from main.
+          #
+          # tina/database.ts writes to branch "main" / collection "main"
+          # unconditionally whenever COSMOS_DB_CONNECTION_STRING and GITHUB_TOKEN
+          # are both set. Since this workflow also runs on pull_request, every PR
+          # preview build was re-indexing the LIVE schema -- with whatever
+          # @tinacms/datalayer version that PR happened to resolve, while the
+          # deployed api/ Function read it with its own. Blanking the connection
+          # string here makes database.ts take its createLocalDatabase() branch,
+          # so the PR still builds (and still proves the bundle compiles) without
+          # touching production.
+          #
+          # Consequence, deliberate: a PR preview's admin reads whatever schema
+          # main last indexed. Schema changes appear in Cosmos only once merged.
+          #
+          # Expression note: written as `!= 'pull_request' && <value> || ''`
+          # rather than `== 'pull_request' && '' || <value>`. GitHub's ternary
+          # idiom falls through on a falsy middle operand, so the latter would
+          # yield <value> on pull_request -- the exact opposite of the intent.
+          COSMOS_DB_CONNECTION_STRING: ${{ github.event_name != 'pull_request' && env.COSMOS_DB_CONNECTION_STRING || '' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}


### PR DESCRIPTION
Every pull request preview build currently re-indexes the **live** TinaCMS schema in Cosmos DB. This gates that to non-PR builds.

## What's happening today

`tina/database.ts` picks its backend like this:

```js
if (isLocal || !cosmosConnectionString || !githubToken) {
  database = createLocalDatabase();
} else {
  // Always use 'main' branch and collection for schema (shared across all environments)
  database = createDatabase({
    gitProvider: new GitHubProvider({ branch: "main", ... }),
    databaseAdapter: new MongodbLevel({ collectionName: "main", ... }),
  });
}
```

There is no branch or event check — only "are the credentials present". This workflow runs on `pull_request` and supplies **both**: `COSMOS_DB_CONNECTION_STRING` from Key Vault into the job env, and `GITHUB_TOKEN` on the build step itself.

So every PR preview writes to production. Confirmed in the build log of an unrelated dependency PR:

```
[TinaCMS Build] Indexing schema to Cosmos DB
  Branch: main, Collection: main
```

## Why it matters

It's benign while every branch resolves the same `@tinacms/datalayer`. It stops being benign the moment one doesn't.

That nearly happened: #177 originally bumped `@tinacms/datalayer` 2.0.12 → 2.0.29 via `npm audit fix`. Its preview build re-indexed production with the **newer writer** while the deployed `api/` Function still reads with **2.0.12**. Neither merging nor closing the PR rolls that back. (#177 has since been narrowed to keep datalayer pinned, so writer and reader match again — but the exposure was real and only avoided by noticing.)

More generally: any PR, from anyone, can perturb production state before a human reviews it.

## The fix

Blank the connection string for this one step on `pull_request`, so `database.ts` takes its `createLocalDatabase()` branch:

```yaml
COSMOS_DB_CONNECTION_STRING: ${{ github.event_name != 'pull_request' && env.COSMOS_DB_CONNECTION_STRING || '' }}
```

The build still runs. PR previews keep proving the admin bundle compiles — they just don't write to the shared collection.

**Deliberate consequence:** a PR preview's admin reads whatever schema `main` last indexed. Schema changes appear in Cosmos only once merged. That's the correct trade for a shared production collection, but it is a behavior change worth knowing about if you preview schema edits.

## On the expression form

It reads awkwardly, and the obvious version is a trap:

```yaml
# WRONG -- silently preserves the bug
${{ github.event_name == 'pull_request' && '' || env.COSMOS_DB_CONNECTION_STRING }}
```

GitHub's ternary idiom falls through on a falsy middle operand. On a pull request that evaluates `true && ''` → `''` → falsy → `'' || <secret>` → **the secret**, i.e. exactly the behavior being fixed, with no error. Inverting the condition avoids it. Simulated both forms against GitHub's truthiness semantics:

| event | this PR | the obvious form |
|---|---|---|
| `pull_request` | empty → local DB ✅ | secret → **writes to prod** ❌ |
| `workflow_run` | secret → indexes ✅ | secret → indexes ✅ |
| `workflow_dispatch` | secret → indexes ✅ | secret → indexes ✅ |

## Verification

Ran `tinacms build --skip-cloud-checks` locally with `COSMOS_DB_CONNECTION_STRING` unset, reproducing what a PR build will now do:

- exits **0**
- still emits `_site/admin/index.html`
- **no** `Indexing schema to Cosmos DB` banner — confirms the local branch was taken

Workflow YAML re-parsed after the edit; `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO` and every other step are unchanged. Only the one `env:` entry and its comment are added.

## Worth considering separately

The root cause is that `branch`/`collection` are hardcoded to `"main"`. Per-branch collections would let previews index their own schema safely instead of being read-only against main's. Bigger change; not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)